### PR TITLE
Rule chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+1.3.0 / 2016-10-24
+==================
+
+  * Rule event emissions
+  * Rule chaining
+
+1.2.1 / 2016-10-22
+==================
+
+  * Use Array.indexOf instead of Array.includes for older node version compatibility
+
+1.2.0 / 2016-09-13
+==================
+
+  * Fact path support
+
+1.1.0 / 2016-09-11
+==================
+
+  * Custom operator support
+
 1.0.4 / 2016-06-18
 ==================
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ engine
  */
 ```
 
-Run this example [here](./examples/nested-boolean-logic.js)
+This is available in the [examples](./examples/02-nested-boolean-logic.js)
 
 ## Advanced Example
 
@@ -179,7 +179,7 @@ engine
  */
 ```
 
-Run this example [here](./examples/nested-boolean-logic.js)
+This is available in the [examples](./examples/03-dynamic-facts)
 
 ## Docs
 

--- a/docs/almanac.md
+++ b/docs/almanac.md
@@ -22,6 +22,14 @@ almanac
   .then( values => console.log(values))
 ```
 
+### almanac.addRuntimeFact(String factId, Mixed value)
+
+Sets a constant fact mid-run.  Often used in conjunction with rule and engine event emissions.
+
+```js
+almanac.addRuntimeFact('account-id', 1)
+```
+
 ## Common Use Cases
 
 ### Fact dependencies
@@ -102,3 +110,38 @@ engine.on('success', (event, almanac) => {
     })
 })
 ```
+
+### Rule Chaining
+
+The `almanac.addRuntimeFact()` method may be used in conjunction with event emissions to
+set fact values during runtime, effectively enabling _rule-chaining_.  Note that ordering
+of rule execution is enabled via the `priority` option, and is crucial component to propertly
+configuring rule chaining.
+
+```js
+engine.addRule({
+  conditions,
+  event,
+  onSuccess: function (event, almanac) {
+    almanac.addRuntimeFact('rule-1-passed', true) // track that the rule passed
+  },
+  onFailure: function (event, almanac) {
+    almanac.addRuntimeFact('rule-1-passed', false) // track that the rule failed
+  },
+  priority: 10 // a higher priority ensures this rule will be run prior to subsequent rules
+})
+
+// in a later rule:
+engine.addRule({
+  conditions: {
+    all: [{
+      fact: 'rule-1-passed',
+      operator: 'equal',
+      value: true
+    }
+  },
+  priority: 1 // lower priority ensures this is run AFTER its predecessor
+}
+```
+
+See the [full example](../examples/07-rule-chaining.js)

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -43,7 +43,9 @@ let Rule = require('json-rules-engine').Rule
 engine.addRule({
   conditions: {},
   event: {},
-  priority: 1
+  priority: 1,                             // optional, default: 1
+  onSuccess: function (event, almanac) {}, // optional
+  onFailure: function (event, almanac) {}, // optional
 })
 
 // or rule instance:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -76,6 +76,29 @@ let rule = new Rule(jsonString) // restored rule; same conditions, priority, eve
 let jsonObject = rule.toJSON(false) // object: {conditions:{ all: [] }, priority: 50 ...
 ```
 
+### Events
+
+Listen for 'success' and 'failure' events emitted when rule is evaluated.
+
+#### ```rule.on('success', Function(Object event, Almanac almanac))```
+
+```js
+// whenever rule is evaluated and the conditions pass, 'success' will trigger
+rule.on('success', function(event, almanac) {
+  console.log(event) // { type: 'my-event', params: { id: 1 }
+})
+```
+
+#### ```rule.on('failure', Function(Object event, Almanac almanac))```
+
+Companion to 'success', except fires when the rule fails.
+
+```js
+engine.on('failure', function(event, almanac) {
+  console.log(event) // { type: 'my-event', params: { id: 1 }
+})
+```
+
 ## Conditions
 
 Each rule condition must begin with a boolean operator(```all``` or ```any```) at its root.

--- a/examples/01-hello-world.js
+++ b/examples/01-hello-world.js
@@ -4,10 +4,10 @@
  * This is the hello-world example from the README.
  *
  * Usage:
- *   node ./examples/hello-world.js
+ *   node ./examples/01-hello-world.js
  *
  * For detailed output:
- *   DEBUG=json-rules-engine node ./examples/hello-world.js
+ *   DEBUG=json-rules-engine node ./examples/01-hello-world.js
  */
 
 require('colors')

--- a/examples/02-nested-boolean-logic.js
+++ b/examples/02-nested-boolean-logic.js
@@ -4,10 +4,10 @@
  * This example demonstates nested boolean logic - e.g. (x OR y) AND (a OR b).
  *
  * Usage:
- *   node ./examples/nested-boolean-logic.js
+ *   node ./examples/02-nested-boolean-logic.js
  *
  * For detailed output:
- *   DEBUG=json-rules-engine node ./examples/nested-boolean-logic.js
+ *   DEBUG=json-rules-engine node ./examples/02-nested-boolean-logic.js
  */
 
 require('colors')

--- a/examples/03-dynamic-facts.js
+++ b/examples/03-dynamic-facts.js
@@ -5,10 +5,10 @@
  * to select object properties returned by facts
  *
  * Usage:
- *   node ./examples/dynamic-facts.js
+ *   node ./examples/03-dynamic-facts.js
  *
  * For detailed output:
- *   DEBUG=json-rules-engine node ./examples/dynamic-facts.js
+ *   DEBUG=json-rules-engine node ./examples/03-dynamic-facts.js
  */
 
 require('colors')

--- a/examples/04-fact-dependency.js
+++ b/examples/04-fact-dependency.js
@@ -6,10 +6,10 @@
  * from outside sources (api's, databases, etc)
  *
  * Usage:
- *   node ./examples/fact-dependency.js
+ *   node ./examples/04-fact-dependency.js
  *
  * For detailed output:
- *   DEBUG=json-rules-engine node ./examples/fact-dependency.js
+ *   DEBUG=json-rules-engine node ./examples/04-fact-dependency.js
  */
 
 require('colors')

--- a/examples/05-optimizing-runtime-with-fact-priorities.js
+++ b/examples/05-optimizing-runtime-with-fact-priorities.js
@@ -4,10 +4,10 @@
  * This is an advanced example that demonstrates using fact priorities to optimize the rules engine.
  *
  * Usage:
- *   node ./examples/optimize-runtime-with-fact-priority.js
+ *   node ./examples/05-optimize-runtime-with-fact-priority.js
  *
  * For detailed output:
- *   DEBUG=json-rules-engine node ./examples/optimize-runtime-with-fact-priority.js
+ *   DEBUG=json-rules-engine node ./examples/05-optimize-runtime-with-fact-priority.js
  */
 
 require('colors')

--- a/examples/06-custom-operators.js
+++ b/examples/06-custom-operators.js
@@ -10,10 +10,10 @@
  * complex example demonstrating asynchronously computed facts, see the fact-dependency example.
  *
  * Usage:
- *   node ./examples/custom-operators.js
+ *   node ./examples/06-custom-operators.js
  *
  * For detailed output:
- *   DEBUG=json-rules-engine node ./examples/custom-operators.js
+ *   DEBUG=json-rules-engine node ./examples/06-custom-operators.js
  */
 
 require('colors')

--- a/examples/07-rule-chaining.js
+++ b/examples/07-rule-chaining.js
@@ -1,0 +1,94 @@
+'use strict'
+
+/*
+ * This is an advanced example demonstrating rules that passed based off the
+ * results of other rules
+ *
+ * Usage:
+ *   node ./examples/07-rule-chaining.js
+ *
+ * For detailed output:
+ *   DEBUG=json-rules-engine node ./examples/07-rule-chaining.js
+ */
+
+require('colors')
+let Engine = require('../dist').Engine
+
+/**
+ * Setup a new engine
+ */
+let engine = new Engine()
+
+/**
+ * Rule for identifying people who may like screwdrivers
+ */
+let drinkRule = {
+  conditions: {
+    all: [{
+      fact: 'drinksOrangeJuice',
+      operator: 'equal',
+      value: true
+    }, {
+      fact: 'enjoysVodka',
+      operator: 'equal',
+      value: true
+    }]
+  },
+  event: { type: 'drinks-screwdrivers' },
+  priority: 10 // IMPORTANT!  Set a higher priority for the drinkRule, so it runs first
+}
+engine.addRule(drinkRule)
+
+/**
+ * Rule for identifying people who should be invited to a screwdriver social
+ * - Only invite people who enjoy screw drivers
+ * - Only invite people who are sociable
+ */
+let inviteRule = {
+  conditions: {
+    all: [{
+      fact: 'screwdriverAficionado', // this fact value is set when the drinkRule is evaluated
+      operator: 'equal',
+      value: true
+    }, {
+      fact: 'isSociable',
+      operator: 'equal',
+      value: true
+    }]
+  },
+  event: { type: 'invite-to-screwdriver-social' },
+  priority: 5 // Set a lower priority for the drinkRule, so it runs later (default: 1)
+}
+engine.addRule(inviteRule)
+
+/**
+ * Register listeners with the engine for rule success and failure
+ */
+let facts
+engine
+  .on('success', (event, almanac) => {
+    console.log(facts.accountId + ' DID '.green + 'meet conditions for the ' + event.type.underline + ' rule.')
+    almanac.addRuntimeFact('screwdriverAficionado', true)
+  })
+  .on('failure', rule => {
+    console.log(facts.accountId + ' did ' + 'NOT'.red + ' meet conditions for the ' + rule.event.type.underline + ' rule.')
+  })
+
+// define fact(s) known at runtime
+facts = { accountId: 'washington', drinksOrangeJuice: true, enjoysVodka: true, isSociable: true, screwdriverAficionado: false }
+engine
+  .run(facts)  // first run, using washington's facts
+  .then(() => {
+    facts = { accountId: 'jefferson', drinksOrangeJuice: true, enjoysVodka: false, isSociable: true, screwdriverAficionado: false }
+    return engine.run(facts) // second run, using jefferson's facts; facts & evaluation are independent of the first run
+  })
+  .catch(console.log)
+
+/*
+ * OUTPUT:
+ *
+ * washington DID meet conditions for the drinks-screwdrivers rule.
+ * washington DID meet conditions for the invite-to-screwdriver-social rule.
+ * jefferson did NOT meet conditions for the drinks-screwdrivers rule.
+ * jefferson did NOT meet conditions for the invite-to-screwdriver-social rule.
+ */

--- a/examples/07-rule-chaining.js
+++ b/examples/07-rule-chaining.js
@@ -35,7 +35,13 @@ let drinkRule = {
     }]
   },
   event: { type: 'drinks-screwdrivers' },
-  priority: 10 // IMPORTANT!  Set a higher priority for the drinkRule, so it runs first
+  priority: 10, // IMPORTANT!  Set a higher priority for the drinkRule, so it runs first
+  onSuccess: function (event, almanac) {
+    almanac.addRuntimeFact('screwdriverAficionado', true)
+  },
+  onFailure: function (event, almanac) {
+    almanac.addRuntimeFact('screwdriverAficionado', false)
+  },
 }
 engine.addRule(drinkRule)
 
@@ -68,18 +74,17 @@ let facts
 engine
   .on('success', (event, almanac) => {
     console.log(facts.accountId + ' DID '.green + 'meet conditions for the ' + event.type.underline + ' rule.')
-    almanac.addRuntimeFact('screwdriverAficionado', true)
   })
   .on('failure', rule => {
     console.log(facts.accountId + ' did ' + 'NOT'.red + ' meet conditions for the ' + rule.event.type.underline + ' rule.')
   })
 
 // define fact(s) known at runtime
-facts = { accountId: 'washington', drinksOrangeJuice: true, enjoysVodka: true, isSociable: true, screwdriverAficionado: false }
+facts = { accountId: 'washington', drinksOrangeJuice: true, enjoysVodka: true, isSociable: true }
 engine
   .run(facts)  // first run, using washington's facts
   .then(() => {
-    facts = { accountId: 'jefferson', drinksOrangeJuice: true, enjoysVodka: false, isSociable: true, screwdriverAficionado: false }
+    facts = { accountId: 'jefferson', drinksOrangeJuice: true, enjoysVodka: false, isSociable: true }
     return engine.run(facts) // second run, using jefferson's facts; facts & evaluation are independent of the first run
   })
   .catch(console.log)

--- a/examples/07-rule-chaining.js
+++ b/examples/07-rule-chaining.js
@@ -41,7 +41,7 @@ let drinkRule = {
   },
   onFailure: function (event, almanac) {
     almanac.addRuntimeFact('screwdriverAficionado', false)
-  },
+  }
 }
 engine.addRule(drinkRule)
 

--- a/test/engine-event.test.js
+++ b/test/engine-event.test.js
@@ -1,6 +1,8 @@
 'use strict'
 
 import engineFactory from '../src/index'
+import Almanac from '../src/almanac'
+import sinon from 'sinon'
 
 describe('Engine: event', () => {
   let engine
@@ -20,66 +22,101 @@ describe('Engine: event', () => {
   }
   beforeEach(() => {
     engine = engineFactory()
-    let determineDrinkingAgeRule = factories.rule({ conditions, event, priority: 100 })
+    let ruleOptions = { conditions, event, priority: 100 }
+    let determineDrinkingAgeRule = factories.rule(ruleOptions)
     engine.addRule(determineDrinkingAgeRule)
     engine.addFact('age', 21)
   })
 
-  it('passes the event type and params', (done) => {
-    engine.on('success', function (a, engine) {
-      try {
-        expect(a).to.eql(event)
-        expect(engine).to.eql(engine)
-      } catch (e) { return done(e) }
-      done()
-    })
-    engine.run()
-  })
-
-  it('emits using the event "type"', (done) => {
-    engine.on('setDrinkingFlag', function (params, engine) {
-      try {
-        expect(params).to.eql(event.params)
-        expect(engine).to.eql(engine)
-      } catch (e) { return done(e) }
-      done()
-    })
-    engine.run()
-  })
-
-  it('allows facts to be added by the event handler, affecting subsequent rules', () => {
-    let drinkOrderParams = { wine: 'merlot', quantity: 2 }
-    let drinkOrderEvent = {
-      type: 'offerDrink',
-      params: drinkOrderParams
-    }
-    let drinkOrderConditions = {
-      any: [{
-        fact: 'canOrderDrinks',
-        operator: 'equal',
-        value: true
-      }]
-    }
-    let drinkOrderRule = factories.rule({
-      conditions: drinkOrderConditions,
-      event: drinkOrderEvent,
-      priority: 1
-    })
-    engine.addRule(drinkOrderRule)
-    return new Promise((resolve, reject) => {
-      engine.on('success', function (event, almanac) {
-        switch (event.type) {
-          case 'setDrinkingFlag':
-            almanac.addRuntimeFact('canOrderDrinks', event.params.canOrderDrinks)
-            break
-          case 'offerDrink':
-            expect(event.params).to.eql(drinkOrderParams)
-            break
-          default:
-            reject(new Error('default case not expected'))
-        }
+  describe('engine events', () => {
+    it('passes the event type and params', (done) => {
+      engine.on('success', function (a, engine) {
+        try {
+          expect(a).to.eql(event)
+          expect(engine).to.eql(engine)
+        } catch (e) { return done(e) }
+        done()
       })
-      engine.run().then(resolve).catch(reject)
+      engine.run()
+    })
+
+    it('emits using the event "type"', (done) => {
+      engine.on('setDrinkingFlag', function (params, e) {
+        try {
+          expect(params).to.eql(event.params)
+          expect(engine).to.eql(e)
+        } catch (e) { return done(e) }
+        done()
+      })
+      engine.run()
+    })
+
+    it('allows facts to be added by the event handler, affecting subsequent rules', () => {
+      let drinkOrderParams = { wine: 'merlot', quantity: 2 }
+      let drinkOrderEvent = {
+        type: 'offerDrink',
+        params: drinkOrderParams
+      }
+      let drinkOrderConditions = {
+        any: [{
+          fact: 'canOrderDrinks',
+          operator: 'equal',
+          value: true
+        }]
+      }
+      let drinkOrderRule = factories.rule({
+        conditions: drinkOrderConditions,
+        event: drinkOrderEvent,
+        priority: 1
+      })
+      engine.addRule(drinkOrderRule)
+      return new Promise((resolve, reject) => {
+        engine.on('success', function (event, almanac) {
+          switch (event.type) {
+            case 'setDrinkingFlag':
+              almanac.addRuntimeFact('canOrderDrinks', event.params.canOrderDrinks)
+              break
+            case 'offerDrink':
+              expect(event.params).to.eql(drinkOrderParams)
+              break
+            default:
+              reject(new Error('default case not expected'))
+          }
+        })
+        engine.run().then(resolve).catch(reject)
+      })
+    })
+  })
+  describe('rule events', () => {
+    it('on-success, it passes the event type and params', (done) => {
+      let failureSpy = sinon.spy()
+      let rule = engine.rules[0]
+      rule.on('success', function (e, a) {
+        try {
+          expect(e).to.eql(event)
+          expect(a).to.be.an.instanceof(Almanac)
+          expect(failureSpy.callCount).to.equal(0)
+        } catch (err) { return done(err) }
+        done()
+      })
+      rule.on('failure', failureSpy)
+      engine.run()
+    })
+
+    it('on-failure, it passes the event type and params', (done) => {
+      let successSpy = sinon.spy()
+      let rule = engine.rules[0]
+      rule.on('failure', function (e, a) {
+        try {
+          expect(e).to.eql(event)
+          expect(a).to.be.an.instanceof(Almanac)
+          expect(successSpy.callCount).to.equal(0)
+        } catch (err) { return done(err) }
+        done()
+      })
+      rule.on('success', successSpy)
+      engine.addFact('age', 10)
+      engine.run()
     })
   })
 })

--- a/test/rule.test.js
+++ b/test/rule.test.js
@@ -52,6 +52,36 @@ describe('Rule', () => {
     })
   })
 
+  describe('event emissions', () => {
+    it('can emit', () => {
+      let rule = new Rule()
+      let successSpy = sinon.spy()
+      rule.on('test', successSpy)
+      rule.emit('test')
+      expect(successSpy.callCount).to.equal(1)
+    })
+
+    it('can be initialized with an onSuccess option', (done) => {
+      let event = { type: 'test' }
+      let onSuccess = function (e) {
+        expect(e).to.equal(event)
+        done()
+      }
+      let rule = new Rule({ onSuccess })
+      rule.emit('success', event)
+    })
+
+    it('can be initialized with an onFailure option', (done) => {
+      let event = { type: 'test' }
+      let onFailure = function (e) {
+        expect(e).to.equal(event)
+        done()
+      }
+      let rule = new Rule({ onFailure })
+      rule.emit('failure', event)
+    })
+  })
+
   describe('setConditions()', () => {
     describe('validations', () => {
       it('throws an exception for invalid root conditions', () => {


### PR DESCRIPTION
- adds rule event emissions for success and failure
- formalizes `rule priorities` + `rule events` + `almanac.setRuntimeFact` as the recommended method for rule chaining
- updates docs and examples accordingly

fixes #7  and #10 