### PR TITLE
fix almanac.factValue incorrectly interpretting path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.5.1 / 2017-03-19
+==================
+
+  * Bugfix almanac.factValue skipping interpreting condition "path" for cached facts
+
 1.5.0 / 2017-03-12
 ==================
 

--- a/dist/almanac.js
+++ b/dist/almanac.js
@@ -38,7 +38,7 @@ var Almanac = function () {
     _classCallCheck(this, Almanac);
 
     this.factMap = new Map(factMap);
-    this.factResultsCache = new Map();
+    this.factResultsCache = new Map(); // { cacheKey:  Promise<factValu> }
 
     for (var factId in runtimeFacts) {
       var fact = void 0;
@@ -131,33 +131,40 @@ var Almanac = function () {
       var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee(factId) {
         var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
         var path = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';
-        var fact, cacheKey, cacheVal, factValue;
+        var factValue, fact, cacheKey, cacheVal;
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
+                factValue = void 0;
                 fact = this._getFact(factId);
                 cacheKey = fact.getCacheKey(params);
                 cacheVal = cacheKey && this.factResultsCache.get(cacheKey);
 
                 if (!cacheVal) {
-                  _context.next = 6;
+                  _context.next = 11;
                   break;
                 }
 
-                cacheVal.then(function (val) {
-                  return debug('almanac::factValue cache hit for fact:' + factId + ' value: ' + JSON.stringify(val) + '<' + (typeof val === 'undefined' ? 'undefined' : _typeof(val)) + '>');
-                });
-                return _context.abrupt('return', cacheVal);
+                _context.next = 7;
+                return cacheVal;
 
-              case 6:
-                verbose('almanac::factValue cache miss for fact:' + factId + '; calculating');
-                _context.next = 9;
-                return this._setFactValue(fact, params, fact.calculate(params, this));
-
-              case 9:
+              case 7:
                 factValue = _context.sent;
 
+                debug('almanac::factValue cache hit for fact:' + factId + ' value: ' + JSON.stringify(factValue) + '<' + (typeof factValue === 'undefined' ? 'undefined' : _typeof(factValue)) + '>');
+                _context.next = 15;
+                break;
+
+              case 11:
+                verbose('almanac::factValue cache miss for fact:' + factId + '; calculating');
+                _context.next = 14;
+                return this._setFactValue(fact, params, fact.calculate(params, this));
+
+              case 14:
+                factValue = _context.sent;
+
+              case 15:
                 if (path) {
                   if (isPlainObject(factValue) || Array.isArray(factValue)) {
                     factValue = selectn(path)(factValue);
@@ -168,7 +175,7 @@ var Almanac = function () {
                 }
                 return _context.abrupt('return', factValue);
 
-              case 12:
+              case 17:
               case 'end':
                 return _context.stop();
             }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha && npm run lint --silent",
     "lint": "standard --verbose | snazzy || true",
+    "lint:fix": "standard --fix",
     "prepublish": "npm run compile",
     "compile": "babel --stage 1 -d dist/ src/ && regenerator --no-cache-dir --include-runtime src/generator-runtime.js > dist/generator-runtime.js"
   },


### PR DESCRIPTION
Reported in #17; when a cached fact value was retrieved by the engine, path was not being interpreted.  This affected conditions using `.path` in two circumstances: when a dynamic fact returning an object was used in multiple rules, and constant facts passed to `engine.run()`