### PR TITLE
Add factResults to condition json if available, increase auditability.

### DIFF
--- a/src/condition.js
+++ b/src/condition.js
@@ -49,6 +49,12 @@ export default class Condition {
       props.operator = this.operator
       props.value = this.value
       props.fact = this.fact
+      if (this.factResult !== undefined) {
+        props.factResult = this.factResult
+      }
+      if (this.result !== undefined) {
+        props.result = this.result
+      }
       if (this.params) {
         props.params = this.params
       }

--- a/test/engine-event.test.js
+++ b/test/engine-event.test.js
@@ -305,7 +305,7 @@ describe('Engine: event', () => {
       rule.on('success', successSpy)
       await engine.run()
       let ruleResult = successSpy.getCall(0).args[2]
-      let expected = '{"conditions":{"priority":1,"any":[{"operator":"greaterThanInclusive","value":21,"fact":"age"},{"operator":"equal","value":true,"fact":"qualified"}]},"event":{"type":"setDrinkingFlag","params":{"canOrderDrinks":true}},"priority":100,"result":true}'
+      let expected = '{"conditions":{"priority":1,"any":[{"operator":"greaterThanInclusive","value":21,"fact":"age","factResult":21,"result":true},{"operator":"equal","value":true,"fact":"qualified","factResult":false,"result":false}]},"event":{"type":"setDrinkingFlag","params":{"canOrderDrinks":true}},"priority":100,"result":true}'
       expect(JSON.stringify(ruleResult)).to.equal(expected)
     })
   })


### PR DESCRIPTION
Adding `factResult` and `result` to the JSON generated for `Condition`

The use case here is that I'd like to store the results of a run and know what the fact (specifically facts that are computed) was at the time and the result of each condition. 

This will allow us to audit decision in the future and know exactly what the decision looked like at the time.

Feedback is welcome!