### PR TITLE
wip: process undefined facts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .DS_Store
 dist
 *.tgz
+*.iml

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -87,7 +87,11 @@ export default class Almanac {
     let factValuePromise
     let fact = this._getFact(factId)
     if (fact === undefined) {
-      return Promise.reject(new UndefinedFactError(`Undefined fact: ${factId}`))
+      // if (engine.processUndefinedFacts) {
+        fact = new Fact(factId, null)
+      // } else {
+        // return Promise.reject(new UndefinedFactError(`Undefined fact: ${factId}`))
+      // }
     }
     if (fact.isConstant()) {
       factValuePromise = Promise.resolve(fact.calculate(params, this))


### PR DESCRIPTION
This is basically what I want to do to fix issue #111 
It fixes the problem for me by allowing to process the undefined fact.
I can add this as an option, but I'm not sure how to access the engine options from the almanac.js file? @CacheControl ?