### PR TITLE
Use Array.isArray instead of instanceof

### DIFF
--- a/src/condition.js
+++ b/src/condition.js
@@ -10,7 +10,7 @@ export default class Condition {
     Object.assign(this, properties)
     if (booleanOperator) {
       let subConditions = properties[booleanOperator]
-      if (!(subConditions instanceof Array)) {
+      if (!(Array.isArray(subConditions))) {
         throw new Error(`"${booleanOperator}" must be an array`)
       }
       this.operator = booleanOperator


### PR DESCRIPTION
`instanceof` does not always return true for an array even if `array.isArray()`
return true and `Object.prototype.toString()` returns `[Object Array]`

http://blog.niftysnippets.org/2010/09/say-what.html#instanceof
https://stackoverflow.com/questions/28779255/is-instanceof-array-better-than-isarray-in-javascript

Fixes #124