### PR TITLE
Replace debug package with console.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.3.5 / 2019-04-26
+  * Replace debug with vanilla console.log
+
 2.3.4 / 2019-04-26
   * Use Array.isArray instead of instanceof to test Array parameters to address edge cases
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,6 +1729,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -4430,7 +4431,8 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "dependencies": {
     "clone": "^2.1.2",
-    "debug": "^4.1.1",
     "events": "^3.0.0",
     "lodash.isobjectlike": "^4.0.0",
     "object-hash": "^1.3.1",

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -2,12 +2,10 @@
 
 import Fact from './fact'
 import { UndefinedFactError } from './errors'
+import debug from './debug'
 
-let debug = require('debug')('json-rules-engine')
-let verbose = require('debug')('json-rules-engine-verbose')
-let selectn = require('selectn')
-let isObjectLike = require('lodash.isobjectlike')
-let warn = require('debug')('json-rules-engine:warn')
+import selectn from 'selectn'
+import isObjectLike from 'lodash.isobjectlike'
 
 /**
  * Fact results lookup
@@ -98,7 +96,7 @@ export default class Almanac {
         factValuePromise = Promise.resolve(cacheVal)
         debug(`almanac::factValue cache hit for fact:${factId}`)
       } else {
-        verbose(`almanac::factValue cache miss for fact:${factId}; calculating`)
+        debug(`almanac::factValue cache miss for fact:${factId}; calculating`)
         factValuePromise = this._setFactValue(fact, params, fact.calculate(params, this))
       }
     }
@@ -110,7 +108,7 @@ export default class Almanac {
             debug(`condition::evaluate extracting object property ${path}, received: ${pathValue}`)
             return pathValue
           } else {
-            warn(`condition::evaluate could not compute object path(${path}) of non-object: ${factValue} <${typeof factValue}>; continuing with ${factValue}`)
+            debug(`condition::evaluate could not compute object path(${path}) of non-object: ${factValue} <${typeof factValue}>; continuing with ${factValue}`)
             return factValue
           }
         })

--- a/src/condition.js
+++ b/src/condition.js
@@ -1,7 +1,7 @@
 'use strict'
 
-let debug = require('debug')('json-rules-engine')
-let isObjectLike = require('lodash.isobjectlike')
+import debug from './debug'
+import isObjectLike from 'lodash.isobjectlike'
 
 export default class Condition {
   constructor (properties) {

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,5 @@
+export default function debug (message) {
+  if (process.env.DEBUG && process.env.DEBUG.match(/json-rules-engine/)) {
+    console.log(message)
+  }
+}

--- a/src/engine.js
+++ b/src/engine.js
@@ -7,8 +7,7 @@ import Almanac from './almanac'
 import { EventEmitter } from 'events'
 import { SuccessEventFact } from './engine-facts'
 import defaultOperators from './engine-default-operators'
-
-let debug = require('debug')('json-rules-engine')
+import debug from './debug'
 
 export const READY = 'READY'
 export const RUNNING = 'RUNNING'

--- a/src/fact.js
+++ b/src/fact.js
@@ -2,8 +2,6 @@
 
 import hash from 'object-hash'
 
-let verbose = require('debug')('json-rules-engine-verbose')
-
 class Fact {
   /**
    * Returns a new fact instance
@@ -66,7 +64,6 @@ class Fact {
    * @return {string} MD5 string based on the hash'd object
    */
   static hashFromObject (obj) {
-    verbose(`fact::hashFromObject generating cache key from:`, obj)
     return hash(obj)
   }
 

--- a/src/rule.js
+++ b/src/rule.js
@@ -3,8 +3,7 @@
 import Condition from './condition'
 import RuleResult from './rule-result'
 import { EventEmitter } from 'events'
-
-let debug = require('debug')('json-rules-engine')
+import debug from './debug'
 
 class Rule extends EventEmitter {
   /**


### PR DESCRIPTION
Newer versions of `debug` have begun using the latest features of ECMAScript, which is causing transpiling pain for front end stakeholders.

Fixes #125