### PR TITLE
Fix undefined fact memory

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -25,7 +25,7 @@ let engine = new Engine([Array rules], options)
 
 `allowUndefinedFacts` - By default, when a running engine encounters an undefined fact,
 an exception is thrown.  Turning this option on will cause the engine to treat
-undefined facts as falsey conditions.  (default: false)
+undefined facts as `undefined`.  (default: false)
 
 ### engine.addFact(String id, Function [definitionFunc], Object [options])
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "standard --verbose --env mocha | snazzy || true",
     "lint:fix": "standard --fix --env mocha",
     "prepublishOnly": "npm run build",
-    "build": "babel --stage 1 -d dist/ src/"
+    "build": "babel --stage 1 -d dist/ src/",
+    "watch": "babel --watch --stage 1 -d dist/ src"
   },
   "repository": {
     "type": "git",

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -13,9 +13,10 @@ import isObjectLike from 'lodash.isobjectlike'
  * A new almanac is used for every engine run()
  */
 export default class Almanac {
-  constructor (factMap, runtimeFacts = {}) {
+  constructor (factMap, runtimeFacts = {}, options = {}) {
     this.factMap = new Map(factMap)
     this.factResultsCache = new Map() // { cacheKey:  Promise<factValu> }
+    this.allowUndefinedFacts = Boolean(options.allowUndefinedFacts)
 
     for (let factId in runtimeFacts) {
       let fact
@@ -85,7 +86,11 @@ export default class Almanac {
     let factValuePromise
     let fact = this._getFact(factId)
     if (fact === undefined) {
-      return Promise.reject(new UndefinedFactError(`Undefined fact: ${factId}`))
+      if (this.allowUndefinedFacts) {
+        return Promise.resolve(undefined)
+      } else {
+        return Promise.reject(new UndefinedFactError(`Undefined fact: ${factId}`))
+      }
     }
     if (fact.isConstant()) {
       factValuePromise = Promise.resolve(fact.calculate(params, this))

--- a/src/engine.js
+++ b/src/engine.js
@@ -212,7 +212,7 @@ class Engine extends EventEmitter {
     debug(`engine::run runtimeFacts:`, runtimeFacts)
     runtimeFacts['success-events'] = new Fact('success-events', SuccessEventFact(), { cache: false })
     this.status = RUNNING
-    let almanac = new Almanac(this.facts, runtimeFacts)
+    let almanac = new Almanac(this.facts, runtimeFacts, { allowUndefinedFacts: this.allowUndefinedFacts })
     let orderedSets = this.prioritizeRules()
     let cursor = Promise.resolve()
     // for each rule set, evaluate in parallel,

--- a/src/rule.js
+++ b/src/rule.js
@@ -161,11 +161,6 @@ class Rule extends EventEmitter {
             condition.result = passes
             return passes
           })
-          .catch(err => {
-            // any condition raising an undefined fact error is considered falsey when allowUndefinedFacts is enabled
-            if (this.engine.allowUndefinedFacts && err.code === 'UNDEFINED_FACT') return false
-            throw err
-          })
       }
     }
 


### PR DESCRIPTION
- [x] Fixes memory/cpu usage outlined in #132 / #96 

This is considered a breaking change because previously all conditions with undefined facts would resolve `false`. With this change, undefined facts resolve as `undefined`.  This means the engine results will change for any rule that would evaluate as truthy given an `undefined` fact value. e.g.

```
{
   'fact': 'age',
   'operator': 'notEqual',
   'value': 10
}
```

Would previously evaluate as `false`. It will not evaluate as `true`, because `undefined != 10`.




