### PR TITLE
Update debug.js

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -1,6 +1,10 @@
 export default function debug (message) {
-  if ((typeof process !== 'undefined' && process.env && process.env.DEBUG && process.env.DEBUG.match(/json-rules-engine/)) ||
-      (typeof window !== 'undefined' && window.localStorage && window.localStorage.debug && window.localStorage.debug.match(/json-rules-engine/))) {
-    console.log(message)
+  try {
+    if ((typeof process !== 'undefined' && process.env && process.env.DEBUG && process.env.DEBUG.match(/json-rules-engine/)) ||
+        (typeof window !== 'undefined' && window.localStorage && window.localStorage.debug && window.localStorage.debug.match(/json-rules-engine/))) {
+      console.log(message)
+    }
+  } catch(ex) {
+    // Do nothing
   }
 }


### PR DESCRIPTION
#184 fix: Wrapping if statement by try/catch block so that if cookies are disabled, debug call doesnt break the code.