### PR TITLE
Made contains and doesNotContain support both strings and arrays 🎉

### DIFF
--- a/src/engine-default-operators.js
+++ b/src/engine-default-operators.js
@@ -8,8 +8,11 @@ Operators.push(new Operator('notEqual', (a, b) => a !== b))
 Operators.push(new Operator('in', (a, b) => b.indexOf(a) > -1))
 Operators.push(new Operator('notIn', (a, b) => b.indexOf(a) === -1))
 
-Operators.push(new Operator('contains', (a, b) => a.indexOf(b) > -1, Array.isArray))
-Operators.push(new Operator('doesNotContain', (a, b) => a.indexOf(b) === -1, Array.isArray))
+function arrayOfStringValidator (factValue) {
+  return Array.isArray(factValue) || (typeof factValue === 'string' || factValue instanceof String)
+}
+Operators.push(new Operator('contains', (a, b) => a.indexOf(b) > -1, arrayOfStringValidator))
+Operators.push(new Operator('doesNotContain', (a, b) => a.indexOf(b) === -1, arrayOfStringValidator))
 
 function numberValidator (factValue) {
   return Number.parseFloat(factValue).toString() !== 'NaN'


### PR DESCRIPTION
It is now possible to use `contains` and `doesNotContain` operators for both strings and arrays.
Following #196 and https://github.com/CacheControl/json-rules-engine/issues/90#issuecomment-414716384.

String validation is based on this [thread comment](https://stackoverflow.com/questions/4059147/check-if-a-variable-is-a-string-in-javascript#comment52648861_9436948).