### PR TITLE
{ Engine }

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![json-rules-engine](http://i.imgur.com/MAzq7l2.png)
-
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 [![Build Status](https://travis-ci.org/CacheControl/json-rules-engine.svg?branch=master)](https://travis-ci.org/CacheControl/json-rules-engine)
 [![npm version](https://badge.fury.io/js/json-rules-engine.svg)](https://badge.fury.io/js/json-rules-engine)
@@ -32,7 +31,8 @@ $ npm install json-rules-engine
 This example demonstrates an engine for detecting whether a basketball player has fouled out (a player who commits five personal fouls over the course of a 40-minute game, or six in a 48-minute game, fouls out).
 
 ```js
-import { Engine } from 'json-rules-engine'
+const Engine = require('json-rules-engine').Engine
+
 
 /**
  * Setup a new engine
@@ -108,7 +108,7 @@ Fact information is loaded via API call during runtime, and the results are cach
 It also demonstates use of the condition _path_ feature to reference properties of objects returned by facts.
 
 ```js
-import { Engine } from 'json-rules-engine'
+const Engine = require('json-rules-engine').Engine
 
 // example client for making asynchronous requests to an api, database, etc
 import apiClient from './account-api-client'

--- a/examples/01-hello-world.js
+++ b/examples/01-hello-world.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This is the hello-world example from the README.
  *
@@ -11,8 +10,8 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
-const Rule = require('../dist').Rule
+const Engine = require('json-rules-engine').Engine
+const Rule = require('json-rules-engine').Rule
 
 /**
  * Setup a new engine

--- a/examples/02-nested-boolean-logic.js
+++ b/examples/02-nested-boolean-logic.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This example demonstates nested boolean logic - e.g. (x OR y) AND (a OR b).
  *
@@ -11,8 +10,7 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
-
+const Engine = require('json-rules-engine').Engine
 /**
  * Setup a new engine
  */

--- a/examples/03-dynamic-facts.js
+++ b/examples/03-dynamic-facts.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This example demonstrates computing fact values at runtime, and leveraging the 'path' feature
  * to select object properties returned by facts
@@ -12,7 +11,7 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
 // example client for making asynchronous requests to an api, database, etc
 const apiClient = require('./support/account-api-client')
 

--- a/examples/04-fact-dependency.js
+++ b/examples/04-fact-dependency.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This is an advanced example that demonstrates facts with dependencies
  * on other facts.  In addition, it demonstrates facts that load data asynchronously
@@ -13,7 +12,7 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
 const accountClient = require('./support/account-api-client')
 
 /**

--- a/examples/05-optimizing-runtime-with-fact-priorities.js
+++ b/examples/05-optimizing-runtime-with-fact-priorities.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This is an advanced example that demonstrates using fact priorities to optimize the rules engine.
  *
@@ -11,7 +10,7 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
 const accountClient = require('./support/account-api-client')
 
 /**

--- a/examples/06-custom-operators.js
+++ b/examples/06-custom-operators.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This example demonstrates using custom operators.
  *
@@ -17,7 +16,8 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
+
 
 /**
  * Setup a new engine

--- a/examples/07-rule-chaining.js
+++ b/examples/07-rule-chaining.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This is an advanced example demonstrating rules that passed based off the
  * results of other rules by adding runtime facts.  It also demonstrates
@@ -13,7 +12,7 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
 
 /**
  * Setup a new engine

--- a/examples/08-fact-comparison.js
+++ b/examples/08-fact-comparison.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This is a basic example demonstrating a condition that compares two facts
  *
@@ -11,7 +10,7 @@
  */
 
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
 
 /**
  * Setup a new engine

--- a/examples/09-rule-results.js
+++ b/examples/09-rule-results.js
@@ -1,5 +1,4 @@
 'use strict'
-
 /*
  * This is a basic example demonstrating how to leverage the metadata supplied by rule results
  *
@@ -10,7 +9,7 @@
  *   DEBUG=json-rules-engine node ./examples/09-rule-results.js
  */
 require('colors')
-const Engine = require('../dist').Engine
+const Engine = require('json-rules-engine').Engine
 
 /**
  * Setup a new engine


### PR DESCRIPTION
Changed import { Engine } from 'json-rules-engine' to const Engine = require('json-rules-engine').Engine in readMe and examples because the latest version node throws error. This is in reference to closed issue (Can't Import Engine #78)