### PR TITLE
Adding to facts described in conditions onSuccess & onFailure callbacks

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -234,7 +234,7 @@ let rule = new Rule({
 See the [fact-comparison](../examples/08-fact-comparison.js) example
 
 ## Facts callbacks
-Sometimes it is necessary to get the result of fulfilling a certain fact. This can be achieved by passing the callbacks of onSuccess or onFailure into fact.Sometimes it is necessary to get the result of fulfilling a certain fact. This can be achieved by passing the callbacks of onSuccess or onFailure into fact.
+Sometimes it is necessary to get the result of fulfilling a certain fact. This can be achieved by passing the callbacks of onSuccess or onFailure into fact.
 
 ```js
 let rule = new Rule({

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -233,6 +233,26 @@ let rule = new Rule({
 ```
 See the [fact-comparison](../examples/08-fact-comparison.js) example
 
+## Facts callbacks
+Sometimes it is necessary to get the result of fulfilling a certain fact. This can be achieved by passing the callbacks of onSuccess or onFailure into fact.Sometimes it is necessary to get the result of fulfilling a certain fact. This can be achieved by passing the callbacks of onSuccess or onFailure into fact.
+
+```js
+let rule = new Rule({
+  conditions: {
+    all: [
+      {
+        fact: 'my-fact',
+        operator: 'lessThanInclusive',
+        value: 1,
+        // result = { fact, operator, value, receivedValue }
+        onSuccess: function (result, almanac) {},
+        onFailure: function (result, almanac) {},
+      }
+    ]
+  }
+})
+```
+
 ## Events
 
 Listen for `success` and `failure` events emitted when rule is evaluated.

--- a/src/condition.js
+++ b/src/condition.js
@@ -105,17 +105,17 @@ export default class Condition {
             return { result, leftHandSideValue, rightHandSideValue, operator: this.operator }
           })
           .then(response => {
-            const event = {
+            const result = {
               fact: this.fact,
               operator: this.operator,
               value: response.rightHandSideValue,
               receivedValue: response.leftHandSideValue
             }
             if (response.result && this.onSuccess) {
-              this.onSuccess(event, almanac)
+              this.onSuccess(result, almanac)
             }
             if (!response.result && this.onFailure) {
-              this.onFailure(event, almanac)
+              this.onFailure(result, almanac)
             }
             return response
           })

--- a/src/condition.js
+++ b/src/condition.js
@@ -104,6 +104,21 @@ export default class Condition {
             debug(`condition::evaluate <${leftHandSideValue} ${this.operator} ${rightHandSideValue}?> (${result})`)
             return { result, leftHandSideValue, rightHandSideValue, operator: this.operator }
           })
+          .then(response => {
+            const event = {
+              fact: this.fact,
+              operator: this.operator,
+              value: response.rightHandSideValue,
+              receivedValue: response.leftHandSideValue
+            }
+            if (response.result && this.onSuccess) {
+              this.onSuccess(event, almanac)
+            }
+            if (!response.result && this.onFailure) {
+              this.onFailure(event, almanac)
+            }
+            return response
+          })
       })
   }
 

--- a/test/condition.test.js
+++ b/test/condition.test.js
@@ -1,4 +1,5 @@
 'use strict'
+import sinon from 'sinon'
 
 import Condition from '../src/condition'
 import defaultOperators from '../src/engine-default-operators'
@@ -279,6 +280,36 @@ describe('Condition', () => {
       const conditions = condition()
       delete conditions.all[0].value
       expect(() => new Condition(conditions)).to.throw(/Condition: constructor "value" property required/)
+    })
+  })
+
+  describe('callback facts', () => {
+    const conditionBase = factories.condition({
+      fact: 'age',
+      value: 50,
+      onSuccess: sinon.spy(),
+      onFailure: sinon.spy()
+    })
+    let condition
+    let almanac
+    function setup (options, factValue) {
+      if (typeof factValue === 'undefined') factValue = 1
+      const properties = Object.assign({}, conditionBase, options)
+      condition = new Condition(properties)
+      const fact = new Fact(conditionBase.fact, factValue)
+      almanac = new Almanac(new Map([[fact.id, fact]]))
+    }
+
+    it('should call onSuccess', async () => {
+      setup({ operator: 'greaterThanInclusive' }, 51)
+      await condition.evaluate(almanac, operators)
+      expect(condition.onSuccess).to.have.been.called()
+    })
+
+    it('should call onFailure', async () => {
+      setup({ operator: 'greaterThanInclusive' }, 49)
+      await condition.evaluate(almanac, operators)
+      expect(condition.onFailure).to.have.been.called()
     })
   })
 

--- a/test/support/condition-factory.js
+++ b/test/support/condition-factory.js
@@ -4,6 +4,8 @@ module.exports = function (options) {
   return {
     fact: options.fact || null,
     value: options.value || null,
-    operator: options.operator || 'equal'
+    operator: options.operator || 'equal',
+    onSuccess: options.onSuccess || null,
+    onFailure: options.onFailure || null
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -135,6 +135,16 @@ export class Rule implements RuleProperties {
   ): T extends true ? string : RuleSerializable;
 }
 
+export type FactHandler = (
+    result: {
+      fact: string;
+      operator: string;
+      value: { fact: string } | any;
+      receivedValue: { fact: string } | any
+    },
+    almanac: Almanac,
+) => void;
+
 interface ConditionProperties {
   fact: string;
   operator: string;
@@ -142,6 +152,8 @@ interface ConditionProperties {
   path?: string;
   priority?: number;
   params?: Record<string, any>;
+  onSuccess?: FactHandler;
+  onFailure?: FactHandler;
 }
 
 type NestedCondition = ConditionProperties | TopLevelCondition;


### PR DESCRIPTION
Sometimes it is necessary to get the result of fulfilling a certain fact. This can be achieved by passing the callbacks of onSuccess or onFailure into fact.