### PR TITLE
feat: add ruleresult in the engineresult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3935,7 +3935,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4406,8 +4405,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4429,7 +4427,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -5281,7 +5278,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -5980,8 +5976,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -6244,8 +6239,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -6387,8 +6381,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",

--- a/src/engine-facts.js
+++ b/src/engine-facts.js
@@ -10,4 +10,14 @@ const SuccessEventFact = function () {
   }
 }
 
-export { SuccessEventFact }
+const SuccessResultFact = function () {
+  const successTriggers = []
+  return (params = {}) => {
+    if (params.ruleResult) {
+      successTriggers.push(params.ruleResult)
+    }
+    return successTriggers
+  }
+}
+
+export { SuccessEventFact, SuccessResultFact }

--- a/test/engine-event.test.js
+++ b/test/engine-event.test.js
@@ -87,7 +87,11 @@ describe('Engine: event', () => {
     it('"success" passes the event, almanac, and results', async () => {
       const failureSpy = sandbox.spy()
       const successSpy = sandbox.spy()
-      engine.on('success', function (e, almanac, ruleResult) {
+      engine.on('success', async function (e, almanac, ruleResult) {
+        // function sleep(ms) {
+        // return new Promise(resolve => setTimeout(resolve, ms));
+        // }
+        // await sleep(2000);
         expect(e).to.eql(event)
         expect(almanac).to.be.an.instanceof(Almanac)
         expect(ruleResult.result).to.be.true()

--- a/test/engine-result.js
+++ b/test/engine-result.js
@@ -1,0 +1,104 @@
+'use strict'
+
+import engineFactory from '../src/index'
+import sinon from 'sinon'
+import { expect } from 'chai'
+
+describe('Engine: result', () => {
+  let engine
+  const event = { type: 'middle-income-adult' }
+  const nestedAnyCondition = {
+    all: [
+      {
+        fact: 'age',
+        operator: 'lessThan',
+        value: 65
+      },
+      {
+        fact: 'age',
+        operator: 'greaterThan',
+        value: 21
+      },
+      {
+        any: [
+          {
+            fact: 'income',
+            operator: 'lessThanInclusive',
+            value: 100
+          },
+          {
+            fact: 'family-size',
+            operator: 'lessThanInclusive',
+            value: 3
+          }
+        ]
+      }
+    ]
+  }
+
+  let sandbox
+  before(() => {
+    sandbox = sinon.createSandbox()
+  })
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  let eventSpy
+  function setup (conditions = nestedAnyCondition) {
+    eventSpy = sandbox.spy()
+
+    engine = engineFactory()
+    const rule = factories.rule({ conditions, event })
+    engine.addRule(rule)
+    engine.on('success', eventSpy)
+  }
+
+  describe('"all" with nested "any"', () => {
+    it('has events and rule result when facts pass rules', async () => {
+      setup()
+      engine.addFact('age', 30)
+      engine.addFact('income', 30)
+      engine.addFact('family-size', 2)
+      const engineResult = await engine.run()
+      expect(eventSpy).to.have.been.calledOnce()
+      expect(engineResult.events.length).to.be.eq(1)
+      expect(engineResult.events[0].type).to.equal(event.type)
+      expect(engineResult.ruleResults.length).to.be.eq(1)
+      expect(engineResult.ruleResults[0].conditions.operator).to.be.eq('all')
+      expect(engineResult.ruleResults[0].conditions.all.length).to.be.eq(3)
+      expect(engineResult.ruleResults[0].conditions.all[0].fact).to.be.eq('age')
+      expect(engineResult.ruleResults[0].conditions.all[0].factResult).to.be.eq(30)
+      expect(engineResult.ruleResults[0].conditions.all[0].value).to.be.eq(65)
+      expect(engineResult.ruleResults[0].conditions.all[0].result).to.be.eq(true)
+      expect(engineResult.ruleResults[0].conditions.all[1].fact).to.be.eq('age')
+      expect(engineResult.ruleResults[0].conditions.all[1].factResult).to.be.eq(30)
+      expect(engineResult.ruleResults[0].conditions.all[1].value).to.be.eq(21)
+      expect(engineResult.ruleResults[0].conditions.all[1].result).to.be.eq(true)
+      expect(engineResult.ruleResults[0].conditions.all[2].result).to.be.eq(true)
+      expect(engineResult.ruleResults[0].conditions.all[2].operator).to.be.eq('any')
+    })
+
+    it('has no events or rule result when facts do not pass rules', async () => {
+      setup()
+      engine.addFact('age', 30)
+      engine.addFact('income', 200)
+      engine.addFact('family-size', 8)
+      const engineResult = await engine.run()
+      expect(eventSpy).to.not.have.been.calledOnce()
+      expect(engineResult.events.length).to.be.eq(0)
+      expect(engineResult.ruleResults.length).to.be.eq(0)
+    })
+
+    it('has no events or rule result when facts do not pass rules', async () => {
+      setup()
+      engine.addFact('age', 12)
+      engine.addFact('income', 30)
+      engine.addFact('family-size', 2)
+      const engineResult = await engine.run()
+      expect(eventSpy).to.not.have.been.calledOnce()
+      expect(engineResult.events.length).to.be.eq(0)
+      expect(engineResult.ruleResults.length).to.be.eq(0)
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ export interface EngineOptions {
 
 export interface EngineResult {
   events: Event[];
-  ruleResult: RuleResult[] 
+  ruleResults: RuleResult[] 
   almanac: Almanac;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,7 @@ export interface EngineOptions {
 
 export interface EngineResult {
   events: Event[];
+  ruleResult: RuleResult[] 
   almanac: Almanac;
 }
 
@@ -142,6 +143,7 @@ interface ConditionProperties {
   path?: string;
   priority?: number;
   params?: Record<string, any>;
+  factResult?: string;
 }
 
 type NestedCondition = ConditionProperties | TopLevelCondition;


### PR DESCRIPTION
Add the RuleResult in the EngineResult so we can use the events, alamanac and conditions once the engine has run and without callbacks. This is useful when running within cloud functions.
The for indexed is not a very elegant solution but I have not found any better.

```js
const runEngine = () => {
  const engineResult = await myEngine.run(payload);
  const promises = [];
  for (var i = 0; i < engineResult.events.length; i++) {
      const event = engineResult.events[i];
      const ruleResult = engineResult.ruleResults[i];
      promises.push(handleSuccess(event, engineResult.almanac, ruleResult));
  }
  return Promise.all(promises);
}
```
