### PR TITLE
Update examples to use json-rule-engine require instead of dist folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install json-rules-engine
 This example demonstrates an engine for detecting whether a basketball player has fouled out (a player who commits five personal fouls over the course of a 40-minute game, or six in a 48-minute game, fouls out).
 
 ```js
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 
 
 /**
@@ -109,7 +109,7 @@ Fact information is loaded via API call during runtime, and the results are cach
 It also demonstates use of the condition _path_ feature to reference properties of objects returned by facts.
 
 ```js
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 
 // example client for making asynchronous requests to an api, database, etc
 import apiClient from './account-api-client'

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,6 @@
+/node_modules
+npm-debug.log
+.vscode
+.idea
+.DS_Store
+*.tgz

--- a/examples/01-hello-world.js
+++ b/examples/01-hello-world.js
@@ -10,8 +10,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
-const Rule = require('json-rules-engine').Rule
+const { Engine, Rule } = require('json-rules-engine')
 
 /**
  * Setup a new engine

--- a/examples/02-nested-boolean-logic.js
+++ b/examples/02-nested-boolean-logic.js
@@ -10,7 +10,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 /**
  * Setup a new engine
  */

--- a/examples/03-dynamic-facts.js
+++ b/examples/03-dynamic-facts.js
@@ -11,7 +11,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 // example client for making asynchronous requests to an api, database, etc
 const apiClient = require('./support/account-api-client')
 

--- a/examples/04-fact-dependency.js
+++ b/examples/04-fact-dependency.js
@@ -12,7 +12,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 const accountClient = require('./support/account-api-client')
 
 /**

--- a/examples/05-optimizing-runtime-with-fact-priorities.js
+++ b/examples/05-optimizing-runtime-with-fact-priorities.js
@@ -10,7 +10,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 const accountClient = require('./support/account-api-client')
 
 /**

--- a/examples/06-custom-operators.js
+++ b/examples/06-custom-operators.js
@@ -16,7 +16,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 
 
 /**

--- a/examples/07-rule-chaining.js
+++ b/examples/07-rule-chaining.js
@@ -12,7 +12,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 
 /**
  * Setup a new engine

--- a/examples/08-fact-comparison.js
+++ b/examples/08-fact-comparison.js
@@ -10,7 +10,7 @@
  */
 
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 
 /**
  * Setup a new engine

--- a/examples/09-rule-results.js
+++ b/examples/09-rule-results.js
@@ -9,7 +9,7 @@
  *   DEBUG=json-rules-engine node ./examples/09-rule-results.js
  */
 require('colors')
-const Engine = require('json-rules-engine').Engine
+const { Engine } = require('json-rules-engine')
 
 /**
  * Setup a new engine

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "examples",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
+    "curriable": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/curriable/-/curriable-1.3.0.tgz",
+      "integrity": "sha512-7kfjDPRSF+pguU0TlfSFBMCd8XlmF29ZAiXcq/zaN4LhZvWdvV0Y72AvaWFqInXZG9Yg1kA1UMkpE9lFBKMpQA=="
+    },
+    "eventemitter2": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
+      "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ=="
+    },
+    "hash-it": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-4.0.5.tgz",
+      "integrity": "sha512-bVZPdJn9GqaAkmGXcBoWG0MKn99VJYYC1X17UWQUPKFxsUSTYMhzz+RdBzCgtG61iT5IwfunE3NKVFZWkAc/OQ==",
+      "requires": {
+        "curriable": "^1.1.0"
+      }
+    },
+    "json-rules-engine": {
+      "version": "6.0.0-alpha-3",
+      "resolved": "https://registry.npmjs.org/json-rules-engine/-/json-rules-engine-6.0.0-alpha-3.tgz",
+      "integrity": "sha512-P575ORK6cKlzAH7UXlRZ7TxWVdBm+eBVhW3MxkehbP+k/mwB+npobFJZp8R5ZHwROhSp+QwgltOne0H4jJQOow==",
+      "requires": {
+        "clone": "^2.1.2",
+        "eventemitter2": "^6.4.3",
+        "hash-it": "^4.0.5",
+        "jsonpath-plus": "^4.0.0",
+        "lodash.isobjectlike": "^4.0.0"
+      }
+    },
+    "jsonpath-plus": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
+      "integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
+    },
+    "lodash.isobjectlike": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isobjectlike/-/lodash.isobjectlike-4.0.0.tgz",
+      "integrity": "sha1-dCxfxlrdJ5JNPSQZFoGqmheytg0="
+    }
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "json-rules-engine-examples",
+  "version": "1.0.0",
+  "description": "examples for json-rule-engine",
+  "main": "",
+  "private": true,
+  "scripts": {
+    "all": "for i in *.js; do node $i; done;"
+  },
+  "author": "Cache Hamm <cache.hamm@gmail.com>",
+  "license": "ISC",
+  "dependencies": {
+    "json-rules-engine": "6.0.0-alpha-3"
+  }
+}


### PR DESCRIPTION
- [x] Adds a package.json to the `examples/` folder. this allows a local checkout of project to execute examples
- [x] Tweaks require syntax throughout project to use object expansion syntax