### PR TITLE
Path resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 #### 6.0. / 2020-12-XX
   * BREAKING CHANGES
-    * Private `rule.event` property renamed. Use `rule.getEvent()` to avoid breaking changes in the future.
+    * `path` support using `selectn` should use the `pathResolver` feature. Read more [here](). To continue using selectn, add the following to the engine constructor:
+      ```js
+      const pathResolver = (value, path) => {
+        return selectn(path)(value)
+      }
+      const engine = new Engine(rules, { pathResolver })
+      ```
     * Engine and Rule events `on('success')`, `on('failure')`, and Rule callbacks `onSuccess` and `onFailure` now honor returned promises; any event handler that returns a promise will be waited upon to resolve before engine execution continues. (fixes #235)
+    * Private `rule.event` property renamed. Use `rule.getEvent()` to avoid breaking changes in the future.
     * The 'success-events' fact used to store successful events has been converted to an internal data structure and will no longer appear in the almanac's facts. (fixes #187)
 
 #### 5.3.0 / 2020-12-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
   * BREAKING CHANGES
     * `path` support using `selectn` should use the `pathResolver` feature. Read more [here](). To continue using selectn, add the following to the engine constructor:
       ```js
-      const pathResolver = (value, path) => {
-        return selectn(path)(value)
+      const pathResolver = (object, path) => {
+        return selectn(path)(object)
       }
       const engine = new Engine(rules, { pathResolver })
       ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### 6.0. / 2020-12-XX
   * BREAKING CHANGES
-    * `path` support using `selectn` should use the `pathResolver` feature. Read more [here](./docs/rules.md#condition-helpers-custom-path-resolver). To continue using `selectn`, add the following to the engine constructor:
+    * To continue using [selectn](https://github.com/wilmoore/selectn.js) syntax for condition `path`s, use the new `pathResolver` feature. Read more [here](./docs/rules.md#condition-helpers-custom-path-resolver). Add the following to the engine constructor:
       ```js
       const pathResolver = (object, path) => {
         return selectn(path)(object)
@@ -12,7 +12,7 @@
     * Private `rule.event` property renamed. Use `rule.getEvent()` to avoid breaking changes in the future.
     * The 'success-events' fact used to store successful events has been converted to an internal data structure and will no longer appear in the almanac's facts. (fixes #187)
   * NEW FEATURES
-    * Engine constructor now accepts a `pathResolver`   option for resolving condition `path` properties. Read more [here](./docs/rules.md#condition-helpers-custom-path-resolver). (fixes #210)
+    * Engine constructor now accepts a `pathResolver` option for resolving condition `path` properties. Read more [here](./docs/rules.md#condition-helpers-custom-path-resolver). (fixes #210)
 
 
 #### 5.3.0 / 2020-12-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 #### 6.0. / 2020-12-XX
   * BREAKING CHANGES
-    * `path` support using `selectn` should use the `pathResolver` feature. Read more [here](). To continue using selectn, add the following to the engine constructor:
+    * `path` support using `selectn` should use the `pathResolver` feature. Read more [here](./docs/rules.md#condition-helpers-custom-path-resolver). To continue using `selectn`, add the following to the engine constructor:
       ```js
       const pathResolver = (object, path) => {
         return selectn(path)(object)
       }
       const engine = new Engine(rules, { pathResolver })
       ```
+      (fixes #205)
     * Engine and Rule events `on('success')`, `on('failure')`, and Rule callbacks `onSuccess` and `onFailure` now honor returned promises; any event handler that returns a promise will be waited upon to resolve before engine execution continues. (fixes #235)
     * Private `rule.event` property renamed. Use `rule.getEvent()` to avoid breaking changes in the future.
     * The 'success-events' fact used to store successful events has been converted to an internal data structure and will no longer appear in the almanac's facts. (fixes #187)
+  * NEW FEATURES
+    * Engine constructor now accepts a `pathResolver`   option for resolving condition `path` properties. Read more [here](./docs/rules.md#condition-helpers-custom-path-resolver). (fixes #210)
+
 
 #### 5.3.0 / 2020-12-02
   * Allow facts to have a value of `undefined`

--- a/docs/almanac.md
+++ b/docs/almanac.md
@@ -1,5 +1,14 @@
 # Almanac
 
+* [Overview](#overview)
+* [Methods](#methods)
+    * [almanac.factValue(Fact fact, Object params, String path) -&gt; Promise](#almanacfactvaluefact-fact-object-params-string-path---promise)
+    * [almanac.addRuntimeFact(String factId, Mixed value)](#almanacaddruntimefactstring-factid-mixed-value)
+* [Common Use Cases](#common-use-cases)
+    * [Fact dependencies](#fact-dependencies)
+    * [Retrieve fact values when handling events](#retrieve-fact-values-when-handling-events)
+    * [Rule Chaining](#rule-chaining)
+
 ## Overview
 
 An almanac collects facts through an engine run cycle.  As the engine computes fact values,

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -2,6 +2,20 @@
 
 The Engine stores and executes rules, emits events, and maintains state.
 
+* [Methods](#methods)
+  * [constructor([Array rules], Object [options])](#constructorarray-rules-object-options)
+    * [Options](#options)
+  * [engine.addFact(String id, Function [definitionFunc], Object [options])](#engineaddfactstring-id-function-definitionfunc-object-options)
+  * [engine.removeFact(String id)](#engineremovefactstring-id)
+  * [engine.addRule(Rule instance|Object options)](#engineaddrulerule-instanceobject-options)
+  * [engine.removeRule(Rule instance)](#engineremoverulerule-instance)
+  * [engine.addOperator(String operatorName, Function evaluateFunc(factValue, jsonValue))](#engineaddoperatorstring-operatorname-function-evaluatefuncfactvalue-jsonvalue)
+  * [engine.removeOperator(String operatorName)](#engineremoveoperatorstring-operatorname)
+  * [engine.run([Object facts], [Object options]) -&gt; Promise ({ events: Events, almanac: Almanac})](#enginerunobject-facts-object-options---promise--events-events-almanac-almanac)
+  * [engine.stop() -&gt; Engine](#enginestop---engine)
+    * [engine.on('success', Function(Object event, Almanac almanac, RuleResult ruleResult))](#engineonsuccess-functionobject-event-almanac-almanac-ruleresult-ruleresult)
+    * [engine.on('failure', Function(Object event, Almanac almanac, RuleResult ruleResult))](#engineonfailure-functionobject-event-almanac-almanac-ruleresult-ruleresult)
+
 ## Methods
 
 ### constructor([Array rules], Object [options])
@@ -16,7 +30,8 @@ let engine = new Engine([Array rules])
 
 // initialize with options
 let options = {
-  allowUndefinedFacts: false
+  allowUndefinedFacts: false,
+  pathResolver: (object, path) => _.get(object, path)
 };
 let engine = new Engine([Array rules], options)
 ```
@@ -26,6 +41,8 @@ let engine = new Engine([Array rules], options)
 `allowUndefinedFacts` - By default, when a running engine encounters an undefined fact,
 an exception is thrown.  Turning this option on will cause the engine to treat
 undefined facts as `undefined`.  (default: false)
+
+`pathResolver` - Allows a custom object path resolution library to be used. (default: `json-path` syntax). See [custom path resolver](./rules.md#condition-helpers-custom-path-resolver) docs.
 
 ### engine.addFact(String id, Function [definitionFunc], Object [options])
 

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -3,6 +3,9 @@
 Facts are methods or constants registered with the engine prior to runtime and referenced within rule conditions.  Each fact method should be a pure function that may return a either computed value, or promise that resolves to a computed value.
 As rule conditions are evaluated during runtime, they retrieve fact values dynamically and use the condition _operator_ to compare the fact result with the condition _value_.
 
+* [Methods](#methods)
+  * [constructor(String id, Constant|Function(Object params, Almanac almanac), [Object options]) -&gt; instance](#constructorstring-id-constantfunctionobject-params-almanac-almanac-object-options---instance)
+
 ## Methods
 
 ### constructor(String id, Constant|Function(Object params, Almanac almanac), [Object options]) -> instance

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -3,15 +3,30 @@
 
 Rules contain a set of _conditions_ and a single _event_.  When the engine is run, each rule condition is evaluated.  If the results are truthy, the rule's _event_ is triggered.
 
-[Methods](#methods)
-
-[Conditions](#conditions)
-
-[Events](#events)
-
-[Operators](#operators)
-
-[Rule Results](#rule-results)
+* [Methods](#methods)
+  * [constructor([Object options|String json])](#constructorobject-optionsstring-json)
+  * [setConditions(Array conditions)](#setconditionsarray-conditions)
+  * [getConditions() -&gt; Object](#getconditions---object)
+  * [setEvent(Object event)](#seteventobject-event)
+  * [getEvent() -&gt; Object](#getevent---object)
+  * [setPriority(Integer priority = 1)](#setpriorityinteger-priority--1)
+  * [getPriority() -&gt; Integer](#getpriority---integer)
+  * [toJSON(Boolean stringify = true)](#tojsonboolean-stringify--true)
+* [Conditions](#conditions)
+  * [Basic conditions](#basic-conditions)
+  * [Boolean expressions: all and any](#boolean-expressions-all-and-any)
+  * [Condition helpers: params](#condition-helpers-params)
+  * [Condition helpers: path](#condition-helpers-path)
+  * [Condition helpers: custom path resolver](#condition-helpers-custom-path-resolver)
+  * [Comparing facts](#comparing-facts)
+* [Events](#events)
+    * [rule.on('success', Function(Object event, Almanac almanac, RuleResult ruleResult))](#ruleonsuccess-functionobject-event-almanac-almanac-ruleresult-ruleresult)
+    * [rule.on('failure', Function(Object event, Almanac almanac, RuleResult ruleResult))](#ruleonfailure-functionobject-event-almanac-almanac-ruleresult-ruleresult)
+* [Operators](#operators)
+  * [String and Numeric operators:](#string-and-numeric-operators)
+  * [Numeric operators:](#numeric-operators)
+  * [Array operators:](#array-operators)
+* [Rule Results](#rule-results)
 
 ## Methods
 
@@ -216,6 +231,34 @@ let rule = new Rule({
 json-path support is provided by [jsonpath-plus](https://github.com/s3u/JSONPath)
 
 For an example, see [fact-dependency](../examples/04-fact-dependency.js)
+
+### Condition helpers: custom `path` resolver
+
+To use a custom path resolver instead of the `json-path` default, a `pathResolver` callback option may be passed to the engine. The callback will be invoked during execution when a `path` property is encountered.
+
+```js
+const { get } = require('lodash') // to use the lodash path resolver, for example
+
+function pathResolver (object, path) {
+  // when the rule below is evaluated:
+  //   "object" will be the 'fact1' value
+  //   "path" will be '.price[0]'
+  return get(object, path)
+}
+const engine = new Engine(rules, { pathResolver })
+engine.addRule(new Rule({
+  conditions: {
+    all: [
+      {
+        fact: 'fact1',
+        path: '.price[0]', // uses lodash path syntax
+        operator: 'equal',
+        value: 1
+      }
+    ]
+  })
+)
+```
 
 ### Comparing facts
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -260,6 +260,8 @@ engine.addRule(new Rule({
 )
 ```
 
+This feature may be useful in cases where the higher performance offered by simpler object traversal DSLs are preferable to the advanced expressions provided by `json-path`. It can also be useful for leveraging more complex DSLs ([jsonata](https://jsonata.org/), for example) that offer more advanced capabilities than `json-path`.
+
 ### Comparing facts
 
 Sometimes it is necessary to compare facts against other facts.  This can be accomplished by nesting the second fact within the `value` property.  This second fact has access to the same `params` and `path` helpers as the primary fact.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,5 +1,11 @@
 # Walkthrough
 
+* [Step 1: Create an Engine](#step-1-create-an-engine)
+* [Step 2: Add Rules](#step-2-add-rules)
+    * [Step 3: Define Facts](#step-3-define-facts)
+* [Step 4: Handing Events](#step-4-handing-events)
+* [Step 5: Run the engine](#step-5-run-the-engine)
+
 ## Step 1: Create an Engine
 
 ```js

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "chai-as-promised": "^7.1.1",
     "colors": "~1.4.0",
     "dirty-chai": "2.0.1",
+    "lodash": "4.17.20",
     "mocha": "^8.1.3",
     "perfy": "^1.1.5",
     "sinon": "^9.0.3",

--- a/src/engine.js
+++ b/src/engine.js
@@ -21,6 +21,7 @@ class Engine extends EventEmitter {
     super()
     this.rules = []
     this.allowUndefinedFacts = options.allowUndefinedFacts || false
+    this.pathResolver = options.pathResolver
     this.operators = new Map()
     this.facts = new Map()
     this.status = READY
@@ -210,7 +211,11 @@ class Engine extends EventEmitter {
   run (runtimeFacts = {}) {
     debug('engine::run started')
     this.status = RUNNING
-    const almanac = new Almanac(this.facts, runtimeFacts, { allowUndefinedFacts: this.allowUndefinedFacts })
+    const almanacOptions = {
+      allowUndefinedFacts: this.allowUndefinedFacts,
+      pathResolver: this.pathResolver
+    }
+    const almanac = new Almanac(this.facts, runtimeFacts, almanacOptions)
     const orderedSets = this.prioritizeRules()
     let cursor = Promise.resolve()
     // for each rule set, evaluate in parallel,

--- a/test/engine-fact.test.js
+++ b/test/engine-fact.test.js
@@ -284,13 +284,14 @@ describe('Engine: fact evaluation', () => {
 
         engine = engineFactory([], { pathResolver })
         const rule = factories.rule({ conditions, event })
-        await engine.run()
         engine.addRule(rule)
         engine.on('success', successSpy)
         engine.on('failure', failureSpy)
+
         await engine.run(fact)
+
         expect(successSpy).to.have.been.calledWith(event)
-        expect(failureSpy).to.not.have.been.calledWith(event)
+        expect(failureSpy).to.not.have.been.called()
       })
     })
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 export interface EngineOptions {
-  allowUndefinedFacts: boolean;
-  pathResolver: string;
+  allowUndefinedFacts?: boolean;
+  pathResolver?: PathResolver;
 }
 
 export interface EngineResult {
@@ -93,6 +93,11 @@ export interface Event {
   type: string;
   params?: Record<string, any>;
 }
+
+export type PathResolver = (
+  value: object,
+  path: string,
+) => any;
 
 export type EventHandler = (
   event: Event,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 export interface EngineOptions {
   allowUndefinedFacts: boolean;
+  pathResolver: string;
 }
 
 export interface EngineResult {


### PR DESCRIPTION
adds path resolver engine option. This allows path syntax other than the `json-path` default. It also replaces the current `selectn` built-in fallback with a long term supported solution via the `pathResolver` callback. Fixes #210 and #187.