### PR TITLE
Add failureEvents to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ export interface EngineOptions {
 
 export interface EngineResult {
   events: Event[];
+  failureEvents: Event[];
   almanac: Almanac;
   results: RuleResult[];
   failureResults: RuleResult[];


### PR DESCRIPTION
From previous PRs, the `type` definition was missing `failureEvents` which is available when accessing through JS https://github.com/CacheControl/json-rules-engine/pull/242

This ensures the compiler can access `failureEvents` as well. 