### PR TITLE
refactored remove rule and added updateRule

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -8,7 +8,8 @@ The Engine stores and executes rules, emits events, and maintains state.
     * [engine.addFact(String id, Function [definitionFunc], Object [options])](#engineaddfactstring-id-function-definitionfunc-object-options)
     * [engine.removeFact(String id)](#engineremovefactstring-id)
     * [engine.addRule(Rule instance|Object options)](#engineaddrulerule-instanceobject-options)
-    * [engine.removeRule(Rule instance)](#engineremoverulerule-instance)
+    * [engine.updateRule(Rule instance|Object options)](#engineupdaterulerule-instanceobject-options)
+    * [engine.removeRule(Rule instance | String ruleId)](#engineremoverulerule-instance)
     * [engine.addOperator(String operatorName, Function evaluateFunc(factValue, jsonValue))](#engineaddoperatorstring-operatorname-function-evaluatefuncfactvalue-jsonvalue)
     * [engine.removeOperator(String operatorName)](#engineremoveoperatorstring-operatorname)
     * [engine.run([Object facts], [Object options]) -&gt; Promise ({ events: [], failureEvents: [], almanac: Almanac, results: [], failureResults: []})](#enginerunobject-facts-object-options---promise--events--failureevents--almanac-almanac-results--failureresults-)
@@ -44,8 +45,6 @@ undefined facts as `undefined`.  (default: false)
 
 `pathResolver` - Allows a custom object path resolution library to be used. (default: `json-path` syntax). See [custom path resolver](./rules.md#condition-helpers-custom-path-resolver) docs.
 
-`ruleKeyField` - By default this field is set to 'id', this field is the rule property that will be used when removing a rule by a key string or when updating rule
-
 ### engine.addFact(String id, Function [definitionFunc], Object [options])
 
 ```js
@@ -75,7 +74,7 @@ engine.removeFact('speed-of-light')
 ### engine.addRule(Rule instance|Object options)
 
 Adds a rule to the engine.  The engine will execute the rule upon the next ```run()```
-if the rule doesn't have value set at rule[engine.ruleKeyField], a random string will be set instead.
+if the rule doesn't have value set at rule.id, a random string will be set instead.
 
 ```js
 let Rule = require('json-rules-engine').Rule
@@ -117,6 +116,8 @@ engine.removeRule(rule.id)
 // adds a rule
 let rule = new Rule()
 engine.addRule(rule)
+
+// change rule condition
 rule.conditions.all = []
 
 //update it

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -44,6 +44,8 @@ undefined facts as `undefined`.  (default: false)
 
 `pathResolver` - Allows a custom object path resolution library to be used. (default: `json-path` syntax). See [custom path resolver](./rules.md#condition-helpers-custom-path-resolver) docs.
 
+`ruleKeyField` - By default this field is set to 'id', this field is the rule property that will be used when removing a rule by a key string or when updating rule
+
 ### engine.addFact(String id, Function [definitionFunc], Object [options])
 
 ```js
@@ -73,6 +75,7 @@ engine.removeFact('speed-of-light')
 ### engine.addRule(Rule instance|Object options)
 
 Adds a rule to the engine.  The engine will execute the rule upon the next ```run()```
+if the rule doesn't have value set at rule[engine.ruleKeyField], a random string will be set instead.
 
 ```js
 let Rule = require('json-rules-engine').Rule
@@ -102,6 +105,22 @@ engine.addRule(rule)
 
 //remove it
 engine.removeRule(rule)
+//or
+engine.removeRule(rule.id)
+```
+
+ ### engine.updateRule(Rule instance|Object options)
+
+ Updates a rule in the engine.
+
+```javascript
+// adds a rule
+let rule = new Rule()
+engine.addRule(rule)
+rule.conditions.all = []
+
+//update it
+engine.updateRule(rule)
 ```
 
 ### engine.addOperator(String operatorName, Function evaluateFunc(factValue, jsonValue))

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -120,7 +120,7 @@ engine.addRule(rule)
 // change rule condition
 rule.conditions.all = []
 
-//update it
+//update it in the engine
 engine.updateRule(rule)
 ```
 

--- a/src/engine.js
+++ b/src/engine.js
@@ -50,7 +50,6 @@ class Engine extends EventEmitter {
       rule = new Rule(properties)
     }
     rule.setEngine(this)
-    if (!rule.id) rule.id = '_' + Math.random().toString(36).substr(2, 9)
     this.rules.push(rule)
     this.prioritizedRules = null
     return this

--- a/src/rule.js
+++ b/src/rule.js
@@ -36,9 +36,7 @@ class Rule extends EventEmitter {
       this.setName(options.name)
     }
 
-    if (options && (options.id)) {
-      this.setId(options.id)
-    }
+    this.setId(options ? options.id : null)
 
     const priority = (options && options.priority) || 1
     this.setPriority(priority)
@@ -63,10 +61,11 @@ class Rule extends EventEmitter {
    * @param {any} id - any truthy input
    */
   setId (id) {
-    if (!id && id !== 0) {
-      throw new Error('Rule "id" must be defined')
+    if (!id) {
+      this.id = '_' + Math.random().toString(36).substr(2, 9)
+    } else {
+      this.id = id
     }
-    this.id = id
     return this
   }
 

--- a/src/rule.js
+++ b/src/rule.js
@@ -15,6 +15,7 @@ class Rule extends EventEmitter {
    * @param {string} options.event.params - parameters to pass to the event listener
    * @param {Object} options.conditions - conditions to evaluate when processing this rule
    * @param {any} options.name - identifier for a particular rule, particularly valuable in RuleResult output
+   * @param {any} options.id - identifier for a particular rule, particularly valuable in RuleResult output
    * @return {Rule} instance
    */
   constructor (options) {
@@ -35,6 +36,10 @@ class Rule extends EventEmitter {
       this.setName(options.name)
     }
 
+    if (options && (options.id)) {
+      this.setId(options.id)
+    }
+
     const priority = (options && options.priority) || 1
     this.setPriority(priority)
 
@@ -50,6 +55,18 @@ class Rule extends EventEmitter {
     priority = parseInt(priority, 10)
     if (priority <= 0) throw new Error('Priority must be greater than zero')
     this.priority = priority
+    return this
+  }
+
+  /**
+   * Sets the unique id of the rule
+   * @param {any} id - any truthy input
+   */
+  setId (id) {
+    if (!id && id !== 0) {
+      throw new Error('Rule "id" must be defined')
+    }
+    this.id = id
     return this
   }
 

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -93,6 +93,11 @@ describe('Engine', () => {
       engine.updateRule(rule)
       expect(engine.rules[0].conditions.all.length).to.equal(0)
     })
+    it('should generate id for rule if not provided', () => {
+      const rule = new Rule(factories.rule())
+      expect(rule.id).to.not.equal(null)
+      expect(rule.id).to.not.equal(undefined)
+    })
     it('should throw error if rule not found', () => {
       const rule1 = new Rule(factories.rule())
       engine.addRule(rule1)

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -84,6 +84,17 @@ describe('Engine', () => {
     })
   })
 
+  describe('updateRule()', () => {
+    it('updates rule', () => {
+      const rule = new Rule(factories.rule())
+      engine.addRule(rule)
+      expect(engine.rules[0].conditions.all.length).to.equal(2)
+      rule.conditions = { all: [] }
+      engine.updateRule(rule)
+      expect(engine.rules[0].conditions.all.length).to.equal(0)
+    })
+  })
+
   describe('removeRule()', () => {
     describe('rule instance', () => {
       it('removes the rule', () => {
@@ -93,14 +104,6 @@ describe('Engine', () => {
         engine.removeRule(rule)
         expect(engine.rules.length).to.equal(0)
         expect(engine.prioritizedRules).to.equal(null)
-      })
-    })
-
-    describe('required fields', () => {
-      it('.conditions', () => {
-        expect(() => {
-          engine.removeRule([])
-        }).to.throw(/Engine: removeRule\(\) rule must be a instance of Rule/)
       })
     })
 
@@ -116,6 +119,14 @@ describe('Engine', () => {
       engine.addRule(rule)
       engine.prioritizeRules()
       engine.removeRule(rule)
+      expect(engine.prioritizedRules).to.equal(null)
+    })
+    it('removes rule based on ruleKey', () => {
+      const rule = new Rule(factories.rule())
+      engine.addRule(rule)
+      expect(engine.rules.length).to.equal(1)
+      engine.removeRule(rule.id)
+      expect(engine.rules.length).to.equal(0)
       expect(engine.prioritizedRules).to.equal(null)
     })
   })

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -93,6 +93,14 @@ describe('Engine', () => {
       engine.updateRule(rule)
       expect(engine.rules[0].conditions.all.length).to.equal(0)
     })
+    it('should throw error if rule not found', () => {
+      const rule1 = new Rule(factories.rule())
+      engine.addRule(rule1)
+      const rule2 = new Rule(factories.rule())
+      expect(() => {
+        engine.updateRule(rule2)
+      }).to.throw(/Engine: updateRule\(\) rule not found/)
+    })
   })
 
   describe('removeRule()', () => {


### PR DESCRIPTION
@CacheControl as we talked, I kept engine.rules as an array. 
with this PR we expect that each rule will have a unique key. the name of the field is customizable in the engine's constructor as you can pass "ruleKeyField" default is ('id').
when adding rule if I see there is no unique key at rule[engine.ruleKeyField] I generate a random string so you can still remove it by key if you want to.
also added updateRule() which is removing the rule and adding him again.
let me know if there is something more I need to do. 
My project needs this functionality as each user in my app can create/remove/update his rules which are stored in MongoDB i need to be able to remove or update them by id.
all unit tests passed and I added 2 more.