### PR TITLE
Add "not" boolean operator

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -134,9 +134,9 @@ let rule = new Rule({
 
 See the [hello-world](../examples/01-hello-world.js) example.
 
-### Boolean expressions: `all` and `any`
+### Boolean expressions: `all`, `any`, and `not`
 
-Each rule's conditions *must* have either an `all` or an `any` operator at its root, containing an array of conditions.  The `all` operator specifies that all conditions contained within must be truthy for the rule to be considered a `success`.  The `any` operator only requires one condition to be truthy for the rule to succeed.
+Each rule's conditions *must* have an `all` or `any` operator containing an array of conditions at its root or a `not` operator containing a single condition.  The `all` operator specifies that all conditions contained within must be truthy for the rule to be considered a `success`.  The `any` operator only requires one condition to be truthy for the rule to succeed. The `not` operator will negate whatever condition it contains.
 
 ```js
 // all:
@@ -158,14 +158,23 @@ let rule = new Rule({
       { /* condition 2 */ },
       { /* condition n */ },
       {
-        all: [ /* more conditions */ ]
+        not: {
+          all: [ /* more conditions */ ]
+        }
       }
     ]
   }
 })
+
+// not:
+let rule = new Rule({
+  conditions: {
+    not: { /* condition */ }
+  }
+})
 ```
 
-Notice in the second example how `all` and `any` can be nested within one another to produce complex boolean expressions.  See the [nested-boolean-logic](../examples/02-nested-boolean-logic.js) example.
+Notice in the second example how `all`, `any`, and 'not' can be nested within one another to produce complex boolean expressions.  See the [nested-boolean-logic](../examples/02-nested-boolean-logic.js) example.
 
 ### Condition helpers: `params`
 
@@ -318,7 +327,7 @@ engine.on('failure', function(event, almanac, ruleResult) {
 
 ## Operators
 
-Each rule condition must begin with a boolean operator(```all``` or ```any```) at its root.
+Each rule condition must begin with a boolean operator(```all```, ```any```, or ```not```) at its root.
 
 The ```operator``` compares the value returned by the ```fact``` to what is stored in the ```value``` property.  If the result is truthy, the condition passes.
 

--- a/examples/02-nested-boolean-logic.js
+++ b/examples/02-nested-boolean-logic.js
@@ -38,9 +38,11 @@ async function start () {
           operator: 'equal',
           value: 48
         }, {
-          fact: 'personalFoulCount',
-          operator: 'greaterThanInclusive',
-          value: 6
+          not: {
+            fact: 'personalFoulCount',
+            operator: 'lessThan',
+            value: 6
+          }
         }]
       }]
     },

--- a/test/condition.test.js
+++ b/test/condition.test.js
@@ -56,6 +56,26 @@ describe('Condition', () => {
       const json = condition.toJSON()
       expect(json).to.equal('{"operator":"equal","value":{"fact":"weight","params":{"unit":"lbs"},"path":".value"},"fact":"age"}')
     })
+
+    it('converts "not" conditions', () => {
+      const properties = {
+        not: {
+          ...factories.condition({
+            fact: 'age',
+            value: {
+              fact: 'weight',
+              params: {
+                unit: 'lbs'
+              },
+              path: '.value'
+            }
+          })
+        }
+      }
+      const condition = new Condition(properties)
+      const json = condition.toJSON()
+      expect(json).to.equal('{"priority":1,"not":{"operator":"equal","value":{"fact":"weight","params":{"unit":"lbs"},"path":".value"},"fact":"age"}}')
+    })
   })
 
   describe('evaluate', () => {
@@ -266,6 +286,24 @@ describe('Condition', () => {
       const conditions = condition()
       conditions.all = { foo: true }
       expect(() => new Condition(conditions)).to.throw(/"all" must be an array/)
+    })
+
+    it('throws if is an array and condition is "not"', () => {
+      const conditions = {
+        not: [{ foo: true }]
+      }
+      expect(() => new Condition(conditions)).to.throw(/"not" cannot be an array/)
+    })
+
+    it('does not throw if is not an array and condition is "not"', () => {
+      const conditions = {
+        not: {
+          fact: 'foo',
+          operator: 'equal',
+          value: 'bar'
+        }
+      }
+      expect(() => new Condition(conditions)).to.not.throw()
     })
   })
 

--- a/test/engine-not.test.js
+++ b/test/engine-not.test.js
@@ -1,0 +1,54 @@
+'use strict'
+
+import sinon from 'sinon'
+import engineFactory from '../src/index'
+
+describe('Engine: "not" conditions', () => {
+  let engine
+  let sandbox
+  before(() => {
+    sandbox = sinon.createSandbox()
+  })
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('supports a single "not" condition', () => {
+    const event = {
+      type: 'ageTrigger',
+      params: {
+        demographic: 'under50'
+      }
+    }
+    const conditions = {
+      not: {
+        fact: 'age',
+        operator: 'greaterThanInclusive',
+        value: 50
+      }
+    }
+    let eventSpy
+    let ageSpy
+    beforeEach(() => {
+      eventSpy = sandbox.spy()
+      ageSpy = sandbox.stub()
+      const rule = factories.rule({ conditions, event })
+      engine = engineFactory()
+      engine.addRule(rule)
+      engine.addFact('age', ageSpy)
+      engine.on('success', eventSpy)
+    })
+
+    it('emits when the condition is met', async () => {
+      ageSpy.returns(10)
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+
+    it('does not emit when the condition fails', () => {
+      ageSpy.returns(75)
+      engine.run()
+      expect(eventSpy).to.not.have.been.calledWith(event)
+    })
+  })
+})

--- a/test/engine-recusive-rules.test.js
+++ b/test/engine-recusive-rules.test.js
@@ -162,4 +162,72 @@ describe('Engine: recursive rules', () => {
       expect(eventSpy).to.not.have.been.calledOnce()
     })
   })
+
+  const notNotCondition = {
+    not: {
+      not: {
+        fact: 'age',
+        operator: 'lessThan',
+        value: 65
+      }
+    }
+  }
+
+  describe('"not" nested directly within a "not"', () => {
+    it('evaluates true when facts pass rules', async () => {
+      setup(notNotCondition)
+      engine.addFact('age', 30)
+      await engine.run()
+      expect(eventSpy).to.have.been.calledOnce()
+    })
+
+    it('evaluates false when facts do not pass rules', async () => {
+      setup(notNotCondition)
+      engine.addFact('age', 65)
+      await engine.run()
+      expect(eventSpy).to.not.have.been.calledOnce()
+    })
+  })
+
+  const nestedNotCondition = {
+    not: {
+      all: [
+        {
+          fact: 'age',
+          operator: 'lessThan',
+          value: 65
+        },
+        {
+          fact: 'age',
+          operator: 'greaterThan',
+          value: 21
+        },
+        {
+          not: {
+            fact: 'income',
+            operator: 'lessThanInclusive',
+            value: 100
+          }
+        }
+      ]
+    }
+  }
+
+  describe('outer "not" with nested "all" and nested "not" condition', () => {
+    it('evaluates true when facts pass rules', async () => {
+      setup(nestedNotCondition)
+      engine.addFact('age', 30)
+      engine.addFact('income', 100)
+      await engine.run()
+      expect(eventSpy).to.have.been.calledOnce()
+    })
+
+    it('evaluates false when facts do not pass rules', async () => {
+      setup(nestedNotCondition)
+      engine.addFact('age', 30)
+      engine.addFact('income', 101)
+      await engine.run()
+      expect(eventSpy).to.not.have.been.calledOnce()
+    })
+  })
 })

--- a/test/rule.test.js
+++ b/test/rule.test.js
@@ -109,7 +109,7 @@ describe('Rule', () => {
   describe('setConditions()', () => {
     describe('validations', () => {
       it('throws an exception for invalid root conditions', () => {
-        expect(rule.setConditions.bind(rule, { foo: true })).to.throw(/"conditions" root must contain a single instance of "all" or "any"/)
+        expect(rule.setConditions.bind(rule, { foo: true })).to.throw(/"conditions" root must contain a single instance of "all", "any", or "not"/)
       })
     })
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -157,4 +157,5 @@ interface ConditionProperties {
 type NestedCondition = ConditionProperties | TopLevelCondition;
 type AllConditions = { all: NestedCondition[] };
 type AnyConditions = { any: NestedCondition[] };
-export type TopLevelCondition = AllConditions | AnyConditions;
+type NotConditions = { not: NestedCondition };
+export type TopLevelCondition = AllConditions | AnyConditions | NotConditions;


### PR DESCRIPTION
I've had difficulty expressing certain rules in a readable way without the ability to negate conditions.

For instance if I wanted to create a rule saying "trigger an event when there is not any condition which is true," I would instead have to express this as "trigger an event when all conditions are false." This means that I would have to write each condition as its logical negation, which potentially affects the readability of the condition.

These changes add in a new `not` boolean operator alongside `all` and `any` which negates the result of whatever single condition is nested inside it.

I believe this addresses issue https://github.com/CacheControl/json-rules-engine/issues/269.