### PR TITLE
Expose UndefinedFactError and add test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,17 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": [
+    "es2015",
+    "stage-0"
+  ],
+  "plugins": [
+    [
+      "babel-plugin-transform-builtin-extend",
+      {
+        "globals": [
+          "Error",
+          "Array"
+        ]
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "tsd": "^0.17.0"
   },
   "dependencies": {
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "clone": "^2.1.2",
     "eventemitter2": "^6.4.4",
     "hash-it": "^5.0.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,8 +1,13 @@
 'use strict'
-
+export const UndefinedFactErrorCode = 'UNDEFINED_FACT';
 export class UndefinedFactError extends Error {
   constructor (...props) {
     super(...props)
-    this.code = 'UNDEFINED_FACT'
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UndefinedFactError)
+    }
+
+    this.code = UndefinedFactErrorCode
   }
 }

--- a/src/json-rules-engine.js
+++ b/src/json-rules-engine.js
@@ -2,8 +2,8 @@ import Engine from './engine'
 import Fact from './fact'
 import Rule from './rule'
 import Operator from './operator'
-
-export { Fact, Rule, Operator, Engine }
+import {UndefinedFactError, UndefinedFactErrorCode} from "./errors";
+export { Fact, Rule, Operator, Engine, UndefinedFactError, UndefinedFactErrorCode }
 export default function (rules, options) {
   return new Engine(rules, options)
 }

--- a/test/almanac.test.js
+++ b/test/almanac.test.js
@@ -163,16 +163,16 @@ describe('Almanac', () => {
       expect(result).to.deep.equal(['George', 'Thomas'])
     })
 
-        it('missing fact throws UndefinedFactError', async () => {
-            almanac = new Almanac()
-            try {
-                await almanac.factValue('foo')
-                expect.fail("Expected an error");
-            } catch (err) {
-                expect(err.code).to.deep.equal(UndefinedFactErrorCode)
-                expect(err).to.instanceof(UndefinedFactError)
-            }
-        })
+    it('missing fact throws UndefinedFactError', async () => {
+        almanac = new Almanac()
+        try {
+            await almanac.factValue('foo')
+            expect.fail("Expected an error");
+        } catch (err) {
+            expect(err.code).to.deep.equal(UndefinedFactErrorCode)
+            expect(err).to.instanceof(UndefinedFactError)
+        }
+    })
     describe('caching', () => {
       function setup (factOptions) {
         const fact = new Fact('foo', async (params, facts) => {

--- a/test/almanac.test.js
+++ b/test/almanac.test.js
@@ -1,168 +1,167 @@
-import {Fact} from '../src/index'
+import { Fact } from '../src/index'
 import Almanac from '../src/almanac'
 import {UndefinedFactError, UndefinedFactErrorCode} from "../src/index";
 import sinon from 'sinon'
 import {expect} from "chai";
 
 describe('Almanac', () => {
-    let almanac
-    let factSpy
-    let sandbox
-    before(() => {
-        sandbox = sinon.createSandbox()
+  let almanac
+  let factSpy
+  let sandbox
+  before(() => {
+    sandbox = sinon.createSandbox()
+  })
+  beforeEach(() => {
+    factSpy = sandbox.spy()
+  })
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('properties', () => {
+    it('has methods for managing facts', () => {
+      almanac = new Almanac()
+      expect(almanac).to.have.property('factValue')
     })
+
+    it('adds runtime facts', () => {
+      almanac = new Almanac(new Map(), { modelId: 'XYZ' })
+      expect(almanac.factMap.get('modelId').value).to.equal('XYZ')
+    })
+  })
+
+  describe('constructor', () => {
+    it('supports runtime facts as key => values', () => {
+      almanac = new Almanac(new Map(), { fact1: 3 })
+      return expect(almanac.factValue('fact1')).to.eventually.equal(3)
+    })
+
+    it('supports runtime fact instances', () => {
+      const fact = new Fact('fact1', 3)
+      almanac = new Almanac(new Map(), { fact1: fact })
+      return expect(almanac.factValue('fact1')).to.eventually.equal(fact.value)
+    })
+  })
+
+  describe('addEvent() / getEvents()', () => {
+    const event = {};
+    ['success', 'failure'].forEach(outcome => {
+      it(`manages ${outcome} events`, () => {
+        almanac = new Almanac()
+        expect(almanac.getEvents(outcome)).to.be.empty()
+        almanac.addEvent(event, outcome)
+        expect(almanac.getEvents(outcome)).to.have.a.lengthOf(1)
+        expect(almanac.getEvents(outcome)[0]).to.equal(event)
+      })
+
+      it('getEvent() filters when outcome provided, or returns all events', () => {
+        almanac = new Almanac()
+        almanac.addEvent(event, 'success')
+        almanac.addEvent(event, 'failure')
+        expect(almanac.getEvents('success')).to.have.a.lengthOf(1)
+        expect(almanac.getEvents('failure')).to.have.a.lengthOf(1)
+        expect(almanac.getEvents()).to.have.a.lengthOf(2)
+      })
+    })
+  })
+
+  describe('arguments', () => {
     beforeEach(() => {
-        factSpy = sandbox.spy()
-    })
-    afterEach(() => {
-        sandbox.restore()
-    })
-
-    describe('properties', () => {
-        it('has methods for managing facts', () => {
-            almanac = new Almanac()
-            expect(almanac).to.have.property('factValue')
-        })
-
-        it('adds runtime facts', () => {
-            almanac = new Almanac(new Map(), {modelId: 'XYZ'})
-            expect(almanac.factMap.get('modelId').value).to.equal('XYZ')
-        })
+      const fact = new Fact('foo', async (params, facts) => {
+        if (params.userId) return params.userId
+        return 'unknown'
+      })
+      const factMap = new Map()
+      factMap.set(fact.id, fact)
+      almanac = new Almanac(factMap)
     })
 
-    describe('constructor', () => {
-        it('supports runtime facts as key => values', () => {
-            almanac = new Almanac(new Map(), {fact1: 3})
-            return expect(almanac.factValue('fact1')).to.eventually.equal(3)
-        })
-
-        it('supports runtime fact instances', () => {
-            const fact = new Fact('fact1', 3)
-            almanac = new Almanac(new Map(), {fact1: fact})
-            return expect(almanac.factValue('fact1')).to.eventually.equal(fact.value)
-        })
+    it('allows parameters to be passed to the fact', async () => {
+      return expect(almanac.factValue('foo')).to.eventually.equal('unknown')
     })
 
-    describe('addEvent() / getEvents()', () => {
-        const event = {};
-        ['success', 'failure'].forEach(outcome => {
-            it(`manages ${outcome} events`, () => {
-                almanac = new Almanac()
-                expect(almanac.getEvents(outcome)).to.be.empty()
-                almanac.addEvent(event, outcome)
-                expect(almanac.getEvents(outcome)).to.have.a.lengthOf(1)
-                expect(almanac.getEvents(outcome)[0]).to.equal(event)
-            })
-
-            it('getEvent() filters when outcome provided, or returns all events', () => {
-                almanac = new Almanac()
-                almanac.addEvent(event, 'success')
-                almanac.addEvent(event, 'failure')
-                expect(almanac.getEvents('success')).to.have.a.lengthOf(1)
-                expect(almanac.getEvents('failure')).to.have.a.lengthOf(1)
-                expect(almanac.getEvents()).to.have.a.lengthOf(2)
-            })
-        })
+    it('allows parameters to be passed to the fact', async () => {
+      return expect(almanac.factValue('foo', { userId: 1 })).to.eventually.equal(1)
     })
 
-    describe('arguments', () => {
-        beforeEach(() => {
-            const fact = new Fact('foo', async (params, facts) => {
-                if (params.userId) return params.userId
-                return 'unknown'
-            })
-            const factMap = new Map()
-            factMap.set(fact.id, fact)
-            almanac = new Almanac(factMap)
-        })
+    it('throws an exception if it encounters an undefined fact', () => {
+      return expect(almanac.factValue('bar')).to.be.rejectedWith(/Undefined fact: bar/)
+    })
+  })
 
-        it('allows parameters to be passed to the fact', async () => {
-            return expect(almanac.factValue('foo')).to.eventually.equal('unknown')
-        })
+  describe('addRuntimeFact', () => {
+    it('adds a key/value pair to the factMap as a fact instance', () => {
+      almanac = new Almanac()
+      almanac.addRuntimeFact('factId', 'factValue')
+      expect(almanac.factMap.get('factId').value).to.equal('factValue')
+    })
+  })
 
-        it('allows parameters to be passed to the fact', async () => {
-            return expect(almanac.factValue('foo', {userId: 1})).to.eventually.equal(1)
-        })
+  describe('_addConstantFact', () => {
+    it('adds fact instances to the factMap', () => {
+      const fact = new Fact('factId', 'factValue')
+      almanac = new Almanac()
+      almanac._addConstantFact(fact)
+      expect(almanac.factMap.get(fact.id).value).to.equal(fact.value)
+    })
+  })
 
-        it('throws an exception if it encounters an undefined fact', () => {
-            return expect(almanac.factValue('bar')).to.be.rejectedWith(/Undefined fact: bar/)
-        })
+  describe('_getFact', _ => {
+    it('retrieves the fact object', () => {
+      const facts = new Map()
+      const fact = new Fact('id', 1)
+      facts.set(fact.id, fact)
+      almanac = new Almanac(facts)
+      expect(almanac._getFact('id')).to.equal(fact)
+    })
+  })
+
+  describe('_setFactValue()', () => {
+    function expectFactResultsCache (expected) {
+      const promise = almanac.factResultsCache.values().next().value
+      expect(promise).to.be.instanceof(Promise)
+      promise.then(value => expect(value).to.equal(expected))
+      return promise
+    }
+
+    function setup (f = new Fact('id', 1)) {
+      fact = f
+      const facts = new Map()
+      facts.set(fact.id, fact)
+      almanac = new Almanac(facts)
+    }
+    let fact
+    const FACT_VALUE = 2
+
+    it('updates the fact results and returns a promise', (done) => {
+      setup()
+      almanac._setFactValue(fact, {}, FACT_VALUE)
+      expectFactResultsCache(FACT_VALUE).then(_ => done()).catch(done)
     })
 
-    describe('addRuntimeFact', () => {
-        it('adds a key/value pair to the factMap as a fact instance', () => {
-            almanac = new Almanac()
-            almanac.addRuntimeFact('factId', 'factValue')
-            expect(almanac.factMap.get('factId').value).to.equal('factValue')
-        })
+    it('honors facts with caching disabled', (done) => {
+      setup(new Fact('id', 1, { cache: false }))
+      const promise = almanac._setFactValue(fact, {}, FACT_VALUE)
+      expect(almanac.factResultsCache.values().next().value).to.be.undefined()
+      promise.then(value => expect(value).to.equal(FACT_VALUE)).then(_ => done()).catch(done)
     })
+  })
 
-    describe('_addConstantFact', () => {
-        it('adds fact instances to the factMap', () => {
-            const fact = new Fact('factId', 'factValue')
-            almanac = new Almanac()
-            almanac._addConstantFact(fact)
-            expect(almanac.factMap.get(fact.id).value).to.equal(fact.value)
-        })
+  describe('factValue()', () => {
+    it('allows "path" to be specified to traverse the fact data with json-path', async () => {
+      const fact = new Fact('foo', {
+        users: [{
+          name: 'George'
+        }, {
+          name: 'Thomas'
+        }]
+      })
+      const factMap = new Map()
+      factMap.set(fact.id, fact)
+      almanac = new Almanac(factMap)
+      const result = await almanac.factValue('foo', null, '$..name')
+      expect(result).to.deep.equal(['George', 'Thomas'])
     })
-
-    describe('_getFact', _ => {
-        it('retrieves the fact object', () => {
-            const facts = new Map()
-            const fact = new Fact('id', 1)
-            facts.set(fact.id, fact)
-            almanac = new Almanac(facts)
-            expect(almanac._getFact('id')).to.equal(fact)
-        })
-    })
-
-    describe('_setFactValue()', () => {
-        function expectFactResultsCache(expected) {
-            const promise = almanac.factResultsCache.values().next().value
-            expect(promise).to.be.instanceof(Promise)
-            promise.then(value => expect(value).to.equal(expected))
-            return promise
-        }
-
-        function setup(f = new Fact('id', 1)) {
-            fact = f
-            const facts = new Map()
-            facts.set(fact.id, fact)
-            almanac = new Almanac(facts)
-        }
-
-        let fact
-        const FACT_VALUE = 2
-
-        it('updates the fact results and returns a promise', (done) => {
-            setup()
-            almanac._setFactValue(fact, {}, FACT_VALUE)
-            expectFactResultsCache(FACT_VALUE).then(_ => done()).catch(done)
-        })
-
-        it('honors facts with caching disabled', (done) => {
-            setup(new Fact('id', 1, {cache: false}))
-            const promise = almanac._setFactValue(fact, {}, FACT_VALUE)
-            expect(almanac.factResultsCache.values().next().value).to.be.undefined()
-            promise.then(value => expect(value).to.equal(FACT_VALUE)).then(_ => done()).catch(done)
-        })
-    })
-
-    describe('factValue()', () => {
-        it('allows "path" to be specified to traverse the fact data with json-path', async () => {
-            const fact = new Fact('foo', {
-                users: [{
-                    name: 'George'
-                }, {
-                    name: 'Thomas'
-                }]
-            })
-            const factMap = new Map()
-            factMap.set(fact.id, fact)
-            almanac = new Almanac(factMap)
-            const result = await almanac.factValue('foo', null, '$..name')
-            expect(result).to.deep.equal(['George', 'Thomas'])
-        })
 
         it('missing fact throws UndefinedFactError', async () => {
             almanac = new Almanac()
@@ -174,33 +173,32 @@ describe('Almanac', () => {
                 expect(err).to.instanceof(UndefinedFactError)
             }
         })
+    describe('caching', () => {
+      function setup (factOptions) {
+        const fact = new Fact('foo', async (params, facts) => {
+          factSpy()
+          return 'unknown'
+        }, factOptions)
+        const factMap = new Map()
+        factMap.set(fact.id, fact)
+        almanac = new Almanac(factMap)
+      }
 
-        describe('caching', () => {
-            function setup(factOptions) {
-                const fact = new Fact('foo', async (params, facts) => {
-                    factSpy()
-                    return 'unknown'
-                }, factOptions)
-                const factMap = new Map()
-                factMap.set(fact.id, fact)
-                almanac = new Almanac(factMap)
-            }
+      it('evaluates the fact every time when fact caching is off', () => {
+        setup({ cache: false })
+        almanac.factValue('foo')
+        almanac.factValue('foo')
+        almanac.factValue('foo')
+        expect(factSpy).to.have.been.calledThrice()
+      })
 
-            it('evaluates the fact every time when fact caching is off', () => {
-                setup({cache: false})
-                almanac.factValue('foo')
-                almanac.factValue('foo')
-                almanac.factValue('foo')
-                expect(factSpy).to.have.been.calledThrice()
-            })
-
-            it('evaluates the fact once when fact caching is on', () => {
-                setup({cache: true})
-                almanac.factValue('foo')
-                almanac.factValue('foo')
-                almanac.factValue('foo')
-                expect(factSpy).to.have.been.calledOnce()
-            })
-        })
+      it('evaluates the fact once when fact caching is on', () => {
+        setup({ cache: true })
+        almanac.factValue('foo')
+        almanac.factValue('foo')
+        almanac.factValue('foo')
+        expect(factSpy).to.have.been.calledOnce()
+      })
     })
+  })
 })

--- a/test/almanac.test.js
+++ b/test/almanac.test.js
@@ -1,192 +1,206 @@
-import { Fact } from '../src/index'
+import {Fact} from '../src/index'
 import Almanac from '../src/almanac'
+import {UndefinedFactError, UndefinedFactErrorCode} from "../src/index";
 import sinon from 'sinon'
+import {expect} from "chai";
 
 describe('Almanac', () => {
-  let almanac
-  let factSpy
-  let sandbox
-  before(() => {
-    sandbox = sinon.createSandbox()
-  })
-  beforeEach(() => {
-    factSpy = sandbox.spy()
-  })
-  afterEach(() => {
-    sandbox.restore()
-  })
-
-  describe('properties', () => {
-    it('has methods for managing facts', () => {
-      almanac = new Almanac()
-      expect(almanac).to.have.property('factValue')
+    let almanac
+    let factSpy
+    let sandbox
+    before(() => {
+        sandbox = sinon.createSandbox()
     })
-
-    it('adds runtime facts', () => {
-      almanac = new Almanac(new Map(), { modelId: 'XYZ' })
-      expect(almanac.factMap.get('modelId').value).to.equal('XYZ')
-    })
-  })
-
-  describe('constructor', () => {
-    it('supports runtime facts as key => values', () => {
-      almanac = new Almanac(new Map(), { fact1: 3 })
-      return expect(almanac.factValue('fact1')).to.eventually.equal(3)
-    })
-
-    it('supports runtime fact instances', () => {
-      const fact = new Fact('fact1', 3)
-      almanac = new Almanac(new Map(), { fact1: fact })
-      return expect(almanac.factValue('fact1')).to.eventually.equal(fact.value)
-    })
-  })
-
-  describe('addEvent() / getEvents()', () => {
-    const event = {};
-    ['success', 'failure'].forEach(outcome => {
-      it(`manages ${outcome} events`, () => {
-        almanac = new Almanac()
-        expect(almanac.getEvents(outcome)).to.be.empty()
-        almanac.addEvent(event, outcome)
-        expect(almanac.getEvents(outcome)).to.have.a.lengthOf(1)
-        expect(almanac.getEvents(outcome)[0]).to.equal(event)
-      })
-
-      it('getEvent() filters when outcome provided, or returns all events', () => {
-        almanac = new Almanac()
-        almanac.addEvent(event, 'success')
-        almanac.addEvent(event, 'failure')
-        expect(almanac.getEvents('success')).to.have.a.lengthOf(1)
-        expect(almanac.getEvents('failure')).to.have.a.lengthOf(1)
-        expect(almanac.getEvents()).to.have.a.lengthOf(2)
-      })
-    })
-  })
-
-  describe('arguments', () => {
     beforeEach(() => {
-      const fact = new Fact('foo', async (params, facts) => {
-        if (params.userId) return params.userId
-        return 'unknown'
-      })
-      const factMap = new Map()
-      factMap.set(fact.id, fact)
-      almanac = new Almanac(factMap)
+        factSpy = sandbox.spy()
+    })
+    afterEach(() => {
+        sandbox.restore()
     })
 
-    it('allows parameters to be passed to the fact', async () => {
-      return expect(almanac.factValue('foo')).to.eventually.equal('unknown')
+    describe('properties', () => {
+        it('has methods for managing facts', () => {
+            almanac = new Almanac()
+            expect(almanac).to.have.property('factValue')
+        })
+
+        it('adds runtime facts', () => {
+            almanac = new Almanac(new Map(), {modelId: 'XYZ'})
+            expect(almanac.factMap.get('modelId').value).to.equal('XYZ')
+        })
     })
 
-    it('allows parameters to be passed to the fact', async () => {
-      return expect(almanac.factValue('foo', { userId: 1 })).to.eventually.equal(1)
+    describe('constructor', () => {
+        it('supports runtime facts as key => values', () => {
+            almanac = new Almanac(new Map(), {fact1: 3})
+            return expect(almanac.factValue('fact1')).to.eventually.equal(3)
+        })
+
+        it('supports runtime fact instances', () => {
+            const fact = new Fact('fact1', 3)
+            almanac = new Almanac(new Map(), {fact1: fact})
+            return expect(almanac.factValue('fact1')).to.eventually.equal(fact.value)
+        })
     })
 
-    it('throws an exception if it encounters an undefined fact', () => {
-      return expect(almanac.factValue('bar')).to.be.rejectedWith(/Undefined fact: bar/)
-    })
-  })
+    describe('addEvent() / getEvents()', () => {
+        const event = {};
+        ['success', 'failure'].forEach(outcome => {
+            it(`manages ${outcome} events`, () => {
+                almanac = new Almanac()
+                expect(almanac.getEvents(outcome)).to.be.empty()
+                almanac.addEvent(event, outcome)
+                expect(almanac.getEvents(outcome)).to.have.a.lengthOf(1)
+                expect(almanac.getEvents(outcome)[0]).to.equal(event)
+            })
 
-  describe('addRuntimeFact', () => {
-    it('adds a key/value pair to the factMap as a fact instance', () => {
-      almanac = new Almanac()
-      almanac.addRuntimeFact('factId', 'factValue')
-      expect(almanac.factMap.get('factId').value).to.equal('factValue')
-    })
-  })
-
-  describe('_addConstantFact', () => {
-    it('adds fact instances to the factMap', () => {
-      const fact = new Fact('factId', 'factValue')
-      almanac = new Almanac()
-      almanac._addConstantFact(fact)
-      expect(almanac.factMap.get(fact.id).value).to.equal(fact.value)
-    })
-  })
-
-  describe('_getFact', _ => {
-    it('retrieves the fact object', () => {
-      const facts = new Map()
-      const fact = new Fact('id', 1)
-      facts.set(fact.id, fact)
-      almanac = new Almanac(facts)
-      expect(almanac._getFact('id')).to.equal(fact)
-    })
-  })
-
-  describe('_setFactValue()', () => {
-    function expectFactResultsCache (expected) {
-      const promise = almanac.factResultsCache.values().next().value
-      expect(promise).to.be.instanceof(Promise)
-      promise.then(value => expect(value).to.equal(expected))
-      return promise
-    }
-
-    function setup (f = new Fact('id', 1)) {
-      fact = f
-      const facts = new Map()
-      facts.set(fact.id, fact)
-      almanac = new Almanac(facts)
-    }
-    let fact
-    const FACT_VALUE = 2
-
-    it('updates the fact results and returns a promise', (done) => {
-      setup()
-      almanac._setFactValue(fact, {}, FACT_VALUE)
-      expectFactResultsCache(FACT_VALUE).then(_ => done()).catch(done)
+            it('getEvent() filters when outcome provided, or returns all events', () => {
+                almanac = new Almanac()
+                almanac.addEvent(event, 'success')
+                almanac.addEvent(event, 'failure')
+                expect(almanac.getEvents('success')).to.have.a.lengthOf(1)
+                expect(almanac.getEvents('failure')).to.have.a.lengthOf(1)
+                expect(almanac.getEvents()).to.have.a.lengthOf(2)
+            })
+        })
     })
 
-    it('honors facts with caching disabled', (done) => {
-      setup(new Fact('id', 1, { cache: false }))
-      const promise = almanac._setFactValue(fact, {}, FACT_VALUE)
-      expect(almanac.factResultsCache.values().next().value).to.be.undefined()
-      promise.then(value => expect(value).to.equal(FACT_VALUE)).then(_ => done()).catch(done)
+    describe('arguments', () => {
+        beforeEach(() => {
+            const fact = new Fact('foo', async (params, facts) => {
+                if (params.userId) return params.userId
+                return 'unknown'
+            })
+            const factMap = new Map()
+            factMap.set(fact.id, fact)
+            almanac = new Almanac(factMap)
+        })
+
+        it('allows parameters to be passed to the fact', async () => {
+            return expect(almanac.factValue('foo')).to.eventually.equal('unknown')
+        })
+
+        it('allows parameters to be passed to the fact', async () => {
+            return expect(almanac.factValue('foo', {userId: 1})).to.eventually.equal(1)
+        })
+
+        it('throws an exception if it encounters an undefined fact', () => {
+            return expect(almanac.factValue('bar')).to.be.rejectedWith(/Undefined fact: bar/)
+        })
     })
-  })
 
-  describe('factValue()', () => {
-    it('allows "path" to be specified to traverse the fact data with json-path', async () => {
-      const fact = new Fact('foo', {
-        users: [{
-          name: 'George'
-        }, {
-          name: 'Thomas'
-        }]
-      })
-      const factMap = new Map()
-      factMap.set(fact.id, fact)
-      almanac = new Almanac(factMap)
-      const result = await almanac.factValue('foo', null, '$..name')
-      expect(result).to.deep.equal(['George', 'Thomas'])
+    describe('addRuntimeFact', () => {
+        it('adds a key/value pair to the factMap as a fact instance', () => {
+            almanac = new Almanac()
+            almanac.addRuntimeFact('factId', 'factValue')
+            expect(almanac.factMap.get('factId').value).to.equal('factValue')
+        })
     })
 
-    describe('caching', () => {
-      function setup (factOptions) {
-        const fact = new Fact('foo', async (params, facts) => {
-          factSpy()
-          return 'unknown'
-        }, factOptions)
-        const factMap = new Map()
-        factMap.set(fact.id, fact)
-        almanac = new Almanac(factMap)
-      }
-
-      it('evaluates the fact every time when fact caching is off', () => {
-        setup({ cache: false })
-        almanac.factValue('foo')
-        almanac.factValue('foo')
-        almanac.factValue('foo')
-        expect(factSpy).to.have.been.calledThrice()
-      })
-
-      it('evaluates the fact once when fact caching is on', () => {
-        setup({ cache: true })
-        almanac.factValue('foo')
-        almanac.factValue('foo')
-        almanac.factValue('foo')
-        expect(factSpy).to.have.been.calledOnce()
-      })
+    describe('_addConstantFact', () => {
+        it('adds fact instances to the factMap', () => {
+            const fact = new Fact('factId', 'factValue')
+            almanac = new Almanac()
+            almanac._addConstantFact(fact)
+            expect(almanac.factMap.get(fact.id).value).to.equal(fact.value)
+        })
     })
-  })
+
+    describe('_getFact', _ => {
+        it('retrieves the fact object', () => {
+            const facts = new Map()
+            const fact = new Fact('id', 1)
+            facts.set(fact.id, fact)
+            almanac = new Almanac(facts)
+            expect(almanac._getFact('id')).to.equal(fact)
+        })
+    })
+
+    describe('_setFactValue()', () => {
+        function expectFactResultsCache(expected) {
+            const promise = almanac.factResultsCache.values().next().value
+            expect(promise).to.be.instanceof(Promise)
+            promise.then(value => expect(value).to.equal(expected))
+            return promise
+        }
+
+        function setup(f = new Fact('id', 1)) {
+            fact = f
+            const facts = new Map()
+            facts.set(fact.id, fact)
+            almanac = new Almanac(facts)
+        }
+
+        let fact
+        const FACT_VALUE = 2
+
+        it('updates the fact results and returns a promise', (done) => {
+            setup()
+            almanac._setFactValue(fact, {}, FACT_VALUE)
+            expectFactResultsCache(FACT_VALUE).then(_ => done()).catch(done)
+        })
+
+        it('honors facts with caching disabled', (done) => {
+            setup(new Fact('id', 1, {cache: false}))
+            const promise = almanac._setFactValue(fact, {}, FACT_VALUE)
+            expect(almanac.factResultsCache.values().next().value).to.be.undefined()
+            promise.then(value => expect(value).to.equal(FACT_VALUE)).then(_ => done()).catch(done)
+        })
+    })
+
+    describe('factValue()', () => {
+        it('allows "path" to be specified to traverse the fact data with json-path', async () => {
+            const fact = new Fact('foo', {
+                users: [{
+                    name: 'George'
+                }, {
+                    name: 'Thomas'
+                }]
+            })
+            const factMap = new Map()
+            factMap.set(fact.id, fact)
+            almanac = new Almanac(factMap)
+            const result = await almanac.factValue('foo', null, '$..name')
+            expect(result).to.deep.equal(['George', 'Thomas'])
+        })
+
+        it('missing fact throws UndefinedFactError', async () => {
+            almanac = new Almanac()
+            try {
+                await almanac.factValue('foo')
+                expect.fail("Expected an error");
+            } catch (err) {
+                expect(err.code).to.deep.equal(UndefinedFactErrorCode)
+                expect(err).to.instanceof(UndefinedFactError)
+            }
+        })
+
+        describe('caching', () => {
+            function setup(factOptions) {
+                const fact = new Fact('foo', async (params, facts) => {
+                    factSpy()
+                    return 'unknown'
+                }, factOptions)
+                const factMap = new Map()
+                factMap.set(fact.id, fact)
+                almanac = new Almanac(factMap)
+            }
+
+            it('evaluates the fact every time when fact caching is off', () => {
+                setup({cache: false})
+                almanac.factValue('foo')
+                almanac.factValue('foo')
+                almanac.factValue('foo')
+                expect(factSpy).to.have.been.calledThrice()
+            })
+
+            it('evaluates the fact once when fact caching is on', () => {
+                setup({cache: true})
+                almanac.factValue('foo')
+                almanac.factValue('foo')
+                almanac.factValue('foo')
+                expect(factSpy).to.have.been.calledOnce()
+            })
+        })
+    })
 })


### PR DESCRIPTION
**PROBLEM**
- `UndefinedFactError` is not exported which makes it hard to `catch`
- UndefinedFactError.code value is not exported with makes it hard to detect
- No tests exist for `UndefinedFactError`

**SOLUTION**
- Export `UndefinedFactError` and `UndefinedFactErrorCode`
- Add unit test
- Add babel plugin for `Error` to make `instanceof` work properly with babel