### PR TITLE
Fix Top Level Condition Reference Failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rules-engine",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Rules Engine expressed in simple json",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/test/engine-condition.test.js
+++ b/test/engine-condition.test.js
@@ -277,4 +277,45 @@ describe('Engine: condition', () => {
       expect(results[0]).to.nested.include(nestedCondition)
     })
   })
+
+  describe('top-level condition reference', () => {
+    const sendEvent = {
+      type: 'checkSending',
+      params: {
+        sendRetirementPayment: true
+      }
+    }
+
+    const retiredName = 'retired'
+    const retiredCondition = {
+      all: [
+        { fact: 'isRetired', operator: 'equal', value: true }
+      ]
+    }
+
+    const sendConditions = {
+      condition: retiredName
+    }
+
+    let eventSpy
+    beforeEach(() => {
+      eventSpy = sandbox.spy()
+      const sendRule = factories.rule({
+        conditions: sendConditions,
+        event: sendEvent
+      })
+      engine = engineFactory()
+
+      engine.addRule(sendRule)
+      engine.setCondition(retiredName, retiredCondition)
+
+      engine.addFact('isRetired', true)
+      engine.on('success', eventSpy)
+    })
+
+    it('evaluates top level conditions correctly', async () => {
+      await engine.run()
+      expect(eventSpy).to.have.been.called()
+    })
+  })
 })


### PR DESCRIPTION
There was no test for the top-level condition reference and this was failing because it was being treated as a `not`

Add a test and fix the bug.