### PR TITLE
Support Facts In Events

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -50,6 +50,8 @@ condition reference that cannot be resolved an exception is thrown. Turning
 this option on will cause the engine to treat unresolvable condition references
 as failed conditions. (default: false)
 
+`replaceFactsInEventParams` - By default when rules succeed or fail the events emitted are clones of the event in the rule declaration. When setting this option to true the parameters on the events will be have any fact references resolved. (default: false)
+
 `pathResolver` - Allows a custom object path resolution library to be used. (default: `json-path` syntax). See [custom path resolver](./rules.md#condition-helpers-custom-path-resolver) docs.
 
 ### engine.addFact(String id, Function [definitionFunc], Object [options])

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -349,6 +349,29 @@ engine.on('failure', function(event, almanac, ruleResult) {
 })
 ```
 
+### Referencing Facts In Events
+
+With the engine option [`replaceFactsInEventParams`](./engine.md#options) the parameters of the event may include references to facts in the same form as [Comparing Facts](#comparing-facts). These references will be replaced with the value of the fact before the event is emitted.
+
+```js
+const engine = new Engine([], { replaceFactsInEventParams: true });
+engine.addRule({
+    conditions: { /* ... */ },
+    event: {
+      type: "gameover",
+      params: {
+        initials: {
+          fact: "currentHighScore",
+          path: "$.initials",
+          params: { foo: 'bar' }
+        }
+      }
+    }
+  })
+```
+
+See [11-using-facts-in-events.js](../examples/11-using-facts-in-events.js) for a complete example.
+
 ## Operators
 
 Each rule condition must begin with a boolean operator(```all```, ```any```, or ```not```) at its root.

--- a/examples/11-using-facts-in-events.js
+++ b/examples/11-using-facts-in-events.js
@@ -1,0 +1,148 @@
+'use strict'
+/*
+ * This is an advanced example demonstrating an event that emits the value
+ * of a fact in it's parameters.
+ *
+ * Usage:
+ *   node ./examples/11-using-facts-in-events.js
+ *
+ * For detailed output:
+ *   DEBUG=json-rules-engine node ./examples/11-using-facts-in-events.js
+ */
+
+require('colors')
+const { Engine, Fact } = require('json-rules-engine')
+
+async function start () {
+  /**
+   * Setup a new engine
+   */
+  const engine = new Engine([], { replaceFactsInEventParams: true })
+
+  // in-memory "database"
+  let currentHighScore = null
+  const currentHighScoreFact = new Fact('currentHighScore', () => currentHighScore)
+
+  /**
+   * Rule for when you've gotten the high score
+   * event will include your score and initials.
+   */
+  const highScoreRule = {
+    conditions: {
+      any: [
+        {
+          fact: 'currentHighScore',
+          operator: 'equal',
+          value: null
+        },
+        {
+          fact: 'score',
+          operator: 'greaterThan',
+          value: {
+            fact: 'currentHighScore',
+            path: '$.score'
+          }
+        }
+      ]
+    },
+    event: {
+      type: 'highscore',
+      params: {
+        initials: { fact: 'initials' },
+        score: { fact: 'score' }
+      }
+    }
+  }
+
+  /**
+   * Rule for when the game is over and you don't have the high score
+   * event will include the previous high score
+   */
+  const gameOverRule = {
+    conditions: {
+      all: [
+        {
+          fact: 'score',
+          operator: 'lessThanInclusive',
+          value: {
+            fact: 'currentHighScore',
+            path: '$.score'
+          }
+        }
+      ]
+    },
+    event: {
+      type: 'gameover',
+      params: {
+        initials: {
+          fact: 'currentHighScore',
+          path: '$.initials'
+        },
+        score: {
+          fact: 'currentHighScore',
+          path: '$.score'
+        }
+      }
+    }
+  }
+  engine.addRule(highScoreRule)
+  engine.addRule(gameOverRule)
+  engine.addFact(currentHighScoreFact)
+
+  /**
+   * Register listeners with the engine for rule success
+   */
+  engine
+    .on('success', async ({ params: { initials, score } }) => {
+      console.log(`HIGH SCORE\n${initials} - ${score}`)
+    })
+    .on('success', ({ type, params }) => {
+      if (type === 'highscore') {
+        currentHighScore = params
+      }
+    })
+
+  let facts = {
+    initials: 'DOG',
+    score: 968
+  }
+
+  // first run, without a high score
+  await engine.run(facts)
+
+  console.log('\n')
+
+  // new player
+  facts = {
+    initials: 'AAA',
+    score: 500
+  }
+
+  // new player hasn't gotten the high score yet
+  await engine.run(facts)
+
+  console.log('\n')
+
+  facts = {
+    initials: 'AAA',
+    score: 1000
+  }
+
+  // second run, with a high score
+  await engine.run(facts)
+}
+
+start()
+
+/*
+ * OUTPUT:
+ *
+ * NEW SCORE:
+ * DOG - 968
+ *
+ * HIGH SCORE:
+ * DOG - 968
+ *
+ * HIGH SCORE:
+ * AAA - 1000
+ */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rules-engine",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "description": "Rules Engine expressed in simple json",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -162,4 +162,14 @@ export default class Almanac {
 
     return factValuePromise
   }
+
+  /**
+   * Interprets value as either a primitive, or if a fact, retrieves the fact value
+   */
+  getValue (value) {
+    if (isObjectLike(value) && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
+      return this.factValue(value.fact, value.params, value.path)
+    }
+    return Promise.resolve(value)
+  }
 }

--- a/src/engine.js
+++ b/src/engine.js
@@ -23,6 +23,7 @@ class Engine extends EventEmitter {
     this.rules = []
     this.allowUndefinedFacts = options.allowUndefinedFacts || false
     this.allowUndefinedConditions = options.allowUndefinedConditions || false
+    this.replaceFactsInEventParams = options.replaceFactsInEventParams || false
     this.pathResolver = options.pathResolver
     this.operators = new Map()
     this.facts = new Map()

--- a/src/rule-result.js
+++ b/src/rule-result.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import deepClone from 'clone'
+import { isObject } from 'lodash'
 
 export default class RuleResult {
   constructor (conditions, event, priority, name) {
@@ -13,6 +14,23 @@ export default class RuleResult {
 
   setResult (result) {
     this.result = result
+  }
+
+  resolveEventParams (almanac) {
+    if (isObject(this.event.params)) {
+      const updates = []
+      for (const key in this.event.params) {
+        if (Object.prototype.hasOwnProperty.call(this.event.params, key)) {
+          updates.push(
+            almanac
+              .getValue(this.event.params[key])
+              .then((val) => (this.event.params[key] = val))
+          )
+        }
+      }
+      return Promise.all(updates)
+    }
+    return Promise.resolve()
   }
 
   toJSON (stringify = true) {

--- a/src/rule.js
+++ b/src/rule.js
@@ -367,8 +367,12 @@ class Rule extends EventEmitter {
      */
     const processResult = (result) => {
       ruleResult.setResult(result)
+      let processEvent = Promise.resolve()
+      if (this.engine.replaceFactsInEventParams) {
+        processEvent = ruleResult.resolveEventParams(almanac)
+      }
       const event = result ? 'success' : 'failure'
-      return this.emitAsync(event, ruleResult.event, almanac, ruleResult).then(
+      return processEvent.then(() => this.emitAsync(event, ruleResult.event, almanac, ruleResult)).then(
         () => ruleResult
       )
     }


### PR DESCRIPTION
This adds support via an engine option flag to allow event params to include reference to facts like values do.
The structure of this is that for event parameters the top-level keys may have the value: `{ "fact": "<fact id>" }` at which point they'll be converted into the actual fact value when the rule is evaluated. You can use path and param helpers the same as any other reference to a fact.

The primary use case for this is as a way to externaize values for the events into facts so they can be shared, or so they can change without the rule needing to change. Additionally moving away from needing event / rule specific handlers allows the rules to more completely configure the system for instance:
```js
const maxBidRule = {
   conditions: {
      all: [
         { condition: "desireable" },
         {
            fact: "remainingCash",
            operator: "greaterThanInclusive",
            value: { fact: "maxBid" }
         }
     ]
  },
  event: {
      type: "bid",
      params: {
          amount: { fact: "maxBid" }
      }
  }
}

const allInRule = {
      conditions: {
         all: [
            { condition: "desireable"  },
            {
                fact: "remainingCash",
                operator: "lessThan",
                value: { fact: "maxBid" }
            }
        ]
    },
   event: {
       type: "bid",
       params: { 
         amount: { fact: "remainingCash" }
       }
   }
 }
```