### PR TITLE
Fix usage of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rules-engine",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "description": "Rules Engine expressed in simple json",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/rule-result.js
+++ b/src/rule-result.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import deepClone from 'clone'
-import { isObject } from 'lodash'
+import isObject from 'lodash.isobjectlike'
 
 export default class RuleResult {
   constructor (conditions, event, priority, name) {


### PR DESCRIPTION
We didn't have lodash as a dependency instead having lodash.isObject builds were working because lodash was a dev dependency.

Resolves #346