### PR TITLE
fix: Function to handle BigInt value in JSON.stringify

### DIFF
--- a/src/condition.js
+++ b/src/condition.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import debug from './debug'
+import { jsonStringifyWithBigInt } from './utils'
 
 export default class Condition {
   constructor (properties) {
@@ -101,9 +102,9 @@ export default class Condition {
     ]).then(([rightHandSideValue, leftHandSideValue]) => {
       const result = op.evaluate(leftHandSideValue, rightHandSideValue)
       debug(
-        `condition::evaluate <${JSON.stringify(leftHandSideValue)} ${
+        `condition::evaluate <${jsonStringifyWithBigInt(leftHandSideValue)} ${
           this.operator
-        } ${JSON.stringify(rightHandSideValue)}?> (${result})`
+        } ${jsonStringifyWithBigInt(rightHandSideValue)}?> (${result})`
       )
       return {
         result,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+export function jsonStringifyWithBigInt (data) {
+    return JSON.stringify(data,
+      (key, value) => {
+        return typeof value === "bigint" ? value.toString() : value;
+      }
+    )
+}


### PR DESCRIPTION
 - https://github.com/CacheControl/json-rules-engine/issues/362
 - This could be a solution for this if we don't want to use any additional library like [superjson](https://github.com/blitz-js/superjson)