### PR TITLE
fix: Updated engine on overload to include generic option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,9 +51,7 @@ export class Engine {
   removeFact(factOrId: string | Fact): boolean;
   getFact<T>(factId: string): Fact<T>;
 
-  on(eventName: "success", handler: EventHandler): this;
-  on(eventName: "failure", handler: EventHandler): this;
-  on(eventName: string, handler: EventHandler): this;
+  on<T = Event>(eventName: string, handler: EventHandler<T>): this;
 
   run(facts?: Record<string, any>, runOptions?: RunOptions): Promise<EngineResult>;
   stop(): this;
@@ -119,8 +117,8 @@ export interface Event {
 
 export type PathResolver = (value: object, path: string) => any;
 
-export type EventHandler = (
-  event: Event,
+export type EventHandler<T = Event> = (
+  event: T,
   almanac: Almanac,
   ruleResult: RuleResult
 ) => void;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,12 +4,14 @@ import rulesEngine, {
   Almanac,
   EngineResult,
   Engine,
+  Event,
   Fact,
   Operator,
   OperatorEvaluator,
   PathResolver,
   Rule,
   RuleProperties,
+  RuleResult,
   RuleSerializable
 } from "../";
 
@@ -93,6 +95,16 @@ expectType<Engine>(engine.addFact(fact));
 expectType<Engine>(engine.addFact(dynamicFact));
 expectType<boolean>(engine.removeFact(fact));
 expectType<Fact<string>>(engine.getFact<string>("test"));
+engine.on('success', (event, almanac, ruleResult) => {
+  expectType<Event>(event)
+  expectType<Almanac>(almanac)
+  expectType<RuleResult>(ruleResult)
+})
+engine.on<{ foo: Array<string> }>('foo', (event, almanac, ruleResult) => {
+  expectType<{ foo: Array<string> }>(event)
+  expectType<Almanac>(almanac)
+  expectType<RuleResult>(ruleResult)
+})
 
 // Run the Engine
 expectType<Promise<EngineResult>>(engine.run({ displayMessage: true }));


### PR DESCRIPTION
### Problem:
When directly subscribing to an emitted event through the engine's `on` method, the parameter types for the callback function do not match the types of the parameters at runtime. This leads to compilation errors when directly subscribing to events.
```ts
// subscribe directly to the 'young-adult' event
engine.on('young-adult-rocky-mnts', (params) => {
  // params: {
  //   giftCard: 'amazon',
  //   value: 50
  // }
  // Should work!
  engine.on('young-adult-rocky-mnts', ({ giftCard, value }) => { // Property 'value' does not exist on type 'Event'.
    console.log(`I got an ${giftCard} card with $${value}!`) 
  })
});
```
```
index.ts:60:40 - error TS2339: Property 'giftCard' does not exist on type 'Event'.
60 engine.on('young-adult-rocky-mnts', ({ giftCard, value }) => { // Property 'value' does not exist on type 'Event'.
index.ts:60:50 - error TS2339: Property 'value' does not exist on type 'Event'.
60 engine.on('young-adult-rocky-mnts', ({ giftCard, value }) => { // Property 'value' does not exist on type 'Event'.
```
### Solution:
By updating the `EventHandler` declaration to make use of an optional generic and by providing a generic overload to the `on` method, users can provide their own typings for the shape of the event emitted.
```ts
export type EventHandler<T = Event> = (
  event: T,
  almanac: Almanac,
  ruleResult: RuleResult
) => void;

on(eventName: "success", handler: EventHandler): this;
on(eventName: "failure", handler: EventHandler): this;
on<T>(eventName: string, handler: EventHandler<T>): this;

```
```ts
interface IYoungAdultEvent {
  giftCard: string,
  value: number
}
engine.run(facts)
// Works!
engine.on<IYoungAdultEvent>('young-adult-rocky-mnts', ({ giftCard, value }) => {
  console.log(`I got an ${giftCard} card with $${value}!`) // I got an amazon card with $50!
})
```