### PR TITLE
Remove lodash.isobjectlike package

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "clone": "^2.1.2",
     "eventemitter2": "^6.4.4",
     "hash-it": "^6.0.0",
-    "jsonpath-plus": "^7.2.0",
-    "lodash.isobjectlike": "^4.0.0"
+    "jsonpath-plus": "^7.2.0"
   }
 }

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -5,7 +5,7 @@ import { UndefinedFactError } from './errors'
 import debug from './debug'
 
 import { JSONPath } from 'jsonpath-plus'
-import isObjectLike from 'lodash.isobjectlike'
+import isObjectLike from 'lodash/isObjectLike'
 
 function defaultPathResolver (value, path) {
   return JSONPath({ path, json: value, wrap: false })

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -5,7 +5,6 @@ import { UndefinedFactError } from './errors'
 import debug from './debug'
 
 import { JSONPath } from 'jsonpath-plus'
-import isObjectLike from 'lodash/isObjectLike'
 
 function defaultPathResolver (value, path) {
   return JSONPath({ path, json: value, wrap: false })
@@ -161,7 +160,7 @@ export default class Almanac {
       debug(`condition::evaluate extracting object property ${path}`)
       return factValuePromise
         .then(factValue => {
-          if (isObjectLike(factValue)) {
+          if (factValue != null && typeof factValue === 'object') {
             const pathValue = this.pathResolver(factValue, path)
             debug(`condition::evaluate extracting object property ${path}, received: ${JSON.stringify(pathValue)}`)
             return pathValue
@@ -179,7 +178,7 @@ export default class Almanac {
    * Interprets value as either a primitive, or if a fact, retrieves the fact value
    */
   getValue (value) {
-    if (isObjectLike(value) && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
+    if (value != null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
       return this.factValue(value.fact, value.params, value.path)
     }
     return Promise.resolve(value)

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -178,7 +178,7 @@ export default class Almanac {
    * Interprets value as either a primitive, or if a fact, retrieves the fact value
    */
   getValue (value) {
-    if (value != null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
+    if (Boolean(value instanceof Object) && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
       return this.factValue(value.fact, value.params, value.path)
     }
     return Promise.resolve(value)

--- a/src/almanac.js
+++ b/src/almanac.js
@@ -178,7 +178,7 @@ export default class Almanac {
    * Interprets value as either a primitive, or if a fact, retrieves the fact value
    */
   getValue (value) {
-    if (Boolean(value instanceof Object) && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
+    if (value != null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'fact')) { // value = { fact: 'xyz' }
       return this.factValue(value.fact, value.params, value.path)
     }
     return Promise.resolve(value)

--- a/src/rule-result.js
+++ b/src/rule-result.js
@@ -1,7 +1,6 @@
 'use strict'
 
 import deepClone from 'clone'
-import isObject from 'lodash/isObjectLike'
 
 export default class RuleResult {
   constructor (conditions, event, priority, name) {
@@ -17,7 +16,7 @@ export default class RuleResult {
   }
 
   resolveEventParams (almanac) {
-    if (isObject(this.event.params)) {
+    if (this.event.params != null && typeof this.event.params === 'object') {
       const updates = []
       for (const key in this.event.params) {
         if (Object.prototype.hasOwnProperty.call(this.event.params, key)) {

--- a/src/rule-result.js
+++ b/src/rule-result.js
@@ -16,7 +16,7 @@ export default class RuleResult {
   }
 
   resolveEventParams (almanac) {
-    if (this.event.params != null && typeof this.event.params === 'object') {
+    if (this.event.params instanceof Object) {
       const updates = []
       for (const key in this.event.params) {
         if (Object.prototype.hasOwnProperty.call(this.event.params, key)) {

--- a/src/rule-result.js
+++ b/src/rule-result.js
@@ -16,7 +16,7 @@ export default class RuleResult {
   }
 
   resolveEventParams (almanac) {
-    if (this.event.params instanceof Object) {
+    if (this.event.params !== null && typeof this.event.params === 'object') {
       const updates = []
       for (const key in this.event.params) {
         if (Object.prototype.hasOwnProperty.call(this.event.params, key)) {

--- a/src/rule-result.js
+++ b/src/rule-result.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import deepClone from 'clone'
-import isObject from 'lodash.isobjectlike'
+import isObject from 'lodash/isObjectLike'
 
 export default class RuleResult {
   constructor (conditions, event, priority, name) {


### PR DESCRIPTION
The presence of the dependency "lodash.isobjectlike": "^4.0.0" in the code is causing BlackDuck to report a vulnerability issue related to Prototype Pollution. 

However, it seems unnecessary to load this dependency separately because the function isObjectLike is already available in the "lodash" library. 

Furthermore, the issue related to Prototype Pollution has been addressed and fixed in version 4.17.12 of "lodash". 

You can refer to the following link for additional information: https://security.snyk.io/vuln/SNYK-JS-LODASH-608086