### PR TITLE
fix(deps): update dependency jsonpath-plus to 10.0.0 due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "clone": "^2.1.2",
     "eventemitter2": "^6.4.4",
     "hash-it": "^6.0.0",
-    "jsonpath-plus": "^7.2.0",
+    "jsonpath-plus": "^10.0.0",
     "lodash.isobjectlike": "^4.0.0"
   }
 }


### PR DESCRIPTION
This is a simple dependency bump of the jsonpath-plus dependency.

This dependency is vulnerable according to Snyk: https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884
As this is a non-major upgrade and I have not seen the vulnerability being mentioned anywhere in the repository I thought I'd open a PR for it.