### PR TITLE
call Rule.ruleEvent by its correct name

### DIFF
--- a/src/rule.js
+++ b/src/rule.js
@@ -101,6 +101,7 @@ class Rule extends EventEmitter {
     this.ruleEvent = {
       type: event.type
     }
+    this.event = this.ruleEvent
     if (event.params) this.ruleEvent.params = event.params
     return this
   }

--- a/test/rule.test.js
+++ b/test/rule.test.js
@@ -30,6 +30,7 @@ describe('Rule', () => {
       expect(rule.priority).to.eql(opts.priority)
       expect(rule.conditions).to.eql(opts.conditions)
       expect(rule.ruleEvent).to.eql(opts.event)
+      expect(rule.event).to.eql(opts.event)
       expect(rule.name).to.eql(opts.name)
     })
 
@@ -52,6 +53,7 @@ describe('Rule', () => {
       expect(rule.priority).to.eql(opts.priority)
       expect(rule.conditions).to.eql(opts.conditions)
       expect(rule.ruleEvent).to.eql(opts.event)
+      expect(rule.event).to.eql(opts.event)
       expect(rule.name).to.eql(opts.name)
     })
   })
@@ -322,6 +324,7 @@ describe('Rule', () => {
       expect(hydratedRule.conditions).to.eql(rule.conditions)
       expect(hydratedRule.priority).to.eql(rule.priority)
       expect(hydratedRule.ruleEvent).to.eql(rule.ruleEvent)
+      expect(hydratedRule.event).to.eql(rule.event)
       expect(hydratedRule.name).to.eql(rule.name)
     })
 
@@ -333,6 +336,7 @@ describe('Rule', () => {
       expect(hydratedRule.conditions).to.eql(rule.conditions)
       expect(hydratedRule.priority).to.eql(rule.priority)
       expect(hydratedRule.ruleEvent).to.eql(rule.ruleEvent)
+      expect(hydratedRule.event).to.eql(rule.event)
       expect(hydratedRule.name).to.eql(rule.name)
     })
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -175,6 +175,9 @@ export class Rule implements RuleProperties {
   constructor(ruleProps: RuleProperties | string);
   name: string;
   conditions: TopLevelCondition;
+  /**
+   * @deprecated Use {@link Rule.event} instead.
+   */
   ruleEvent: Event;
   event: Event
   priority: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ export default function engineFactory(
 export class Engine {
   constructor(rules?: Array<RuleProperties>, options?: EngineOptions);
 
-  addRule(rule: RuleProperties): this;
+  addRule(rule: RuleProperties | Rule): this;
   removeRule(ruleOrName: Rule | string): boolean;
   updateRule(rule: Rule): void;
 
@@ -171,11 +171,11 @@ export interface RuleResult {
   ): T extends true ? string : RuleResultSerializable;
 }
 
-export class Rule implements RuleProperties {
+export class Rule {
   constructor(ruleProps: RuleProperties | string);
   name: string;
   conditions: TopLevelCondition;
-  event: Event;
+  ruleEvent: Event;
   priority: number;
   setConditions(conditions: TopLevelCondition): this;
   setEvent(event: Event): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ export default function engineFactory(
 export class Engine {
   constructor(rules?: Array<RuleProperties>, options?: EngineOptions);
 
-  addRule(rule: RuleProperties | Rule): this;
+  addRule(rule: RuleProperties): this;
   removeRule(ruleOrName: Rule | string): boolean;
   updateRule(rule: Rule): void;
 
@@ -171,11 +171,12 @@ export interface RuleResult {
   ): T extends true ? string : RuleResultSerializable;
 }
 
-export class Rule {
+export class Rule implements RuleProperties {
   constructor(ruleProps: RuleProperties | string);
   name: string;
   conditions: TopLevelCondition;
   ruleEvent: Event;
+  event: Event
   priority: number;
   setConditions(conditions: TopLevelCondition): this;
   setEvent(event: Event): this;


### PR DESCRIPTION
Currently, the [types](https://github.com/CacheControl/json-rules-engine/blob/00061aceb905d1b0e8f571ef3baf200dc32ded61/types/index.d.ts#L178) suggest that `Rule` has a property called `event`, but the property is actually called `ruleEvent`, as evidenced by [this test](https://github.com/CacheControl/json-rules-engine/blob/00061aceb905d1b0e8f571ef3baf200dc32ded61/test/rule.test.js#L32). This PR fixes that by changing the type of `Rule`. This is not breaking because any TypeScript code referring to a `Rule`'s `event` can never have worked.