### PR TITLE
Add evaluate to operator type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,6 +72,7 @@ export class Operator<A = unknown, B = unknown> {
     evaluator: OperatorEvaluator<A, B>,
     validator?: (factValue: A) => boolean
   );
+  evaluate(factValue: A, compareToValue: B): boolean;
 }
 
 export interface OperatorDecoratorEvaluator<A, B, NextA, NextB> {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -90,6 +90,7 @@ const operator: Operator = new Operator(
 );
 expectType<void>(engine.addOperator(operator));
 expectType<boolean>(engine.removeOperator(operator));
+expectType<boolean>(operator.evaluate(1, 1));
 
 // Operator Decorator tests
 const operatorDecoratorEvaluator: OperatorDecoratorEvaluator<number[], number, number, number> = (


### PR DESCRIPTION
The operator class has an `evaluate` method. It's helpful to be able to call it explicitly to test custom operators so I'm updating the type definition to include it.