### PR TITLE
Make Rule.conditions readonly

### DIFF
--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -93,7 +93,7 @@ describe('Engine', () => {
       expect(engine.rules[0].conditions.all.length).to.equal(2)
       expect(engine.rules[1].conditions.all.length).to.equal(2)
 
-      rule1.conditions = { all: [] }
+      rule1.setConditions({ all: [] })
       engine.updateRule(rule1)
 
       rule1 = engine.rules.find(rule => rule.name === 'rule1')

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -102,6 +102,20 @@ describe('Engine', () => {
       expect(rule2.conditions.all.length).to.equal(2)
     })
 
+    it('updates rule incorrectly', async () => {
+      const rule1 = new Rule(factories.rule({ name: 'rule1' }))
+      engine.addRule(rule1)
+
+      rule1.conditions = { all: [] } // Rule.conditions should not be set to a value that is not an instance of Condition
+      engine.updateRule(rule1)
+
+      const successSpy = sandbox.spy()
+      rule1.on('success', successSpy)
+      await engine.run()
+      const ruleResult = successSpy.getCall(0).args[2]
+      expect(() => JSON.stringify(ruleResult)).to.throw(/toJSON is not a function/)
+    })
+
     it('should throw error if rule not found', () => {
       const rule1 = new Rule(factories.rule({ name: 'rule1' }))
       engine.addRule(rule1)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -174,7 +174,7 @@ export interface RuleResult {
 export class Rule implements RuleProperties {
   constructor(ruleProps: RuleProperties | string);
   name: string;
-  conditions: TopLevelCondition;
+  readonly conditions: TopLevelCondition;
   /**
    * @deprecated Use {@link Rule.event} instead.
    */


### PR DESCRIPTION
This

- changes a test to use the correct setter method to change a Rule's conditions
- adds a test that shows that Rule.conditions is not the right setter
- marks Rule.conditions as readonly in the types