### PR TITLE
Allow params in fact and event to be an array of Record<K,T>

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -91,7 +91,7 @@ export class Almanac {
   constructor(options?: AlmanacOptions);
   factValue<T>(
     factId: string,
-    params?: Record<string, any>,
+    params?: TParams,
     path?: string
   ): Promise<T>;
   addFact<T>(fact: Fact<T>): this;
@@ -108,8 +108,10 @@ export type FactOptions = {
   priority?: number;
 };
 
+type TParams = Record<string, any> | Record<string, any>[];
+
 export type DynamicFactCallback<T = unknown> = (
-  params: Record<string, any>,
+  params: TParams,
   almanac: Almanac
 ) => T;
 
@@ -129,7 +131,7 @@ export class Fact<T = unknown> {
 
 export interface Event {
   type: string;
-  params?: Record<string, any>;
+  params?: TParams;
 }
 
 export type PathResolver = (value: object, path: string) => any;
@@ -205,7 +207,7 @@ interface ConditionProperties {
   value: { fact: string } | any;
   path?: string;
   priority?: number;
-  params?: Record<string, any>;
+  params?: TParams;
   name?: string;
 }
 


### PR DESCRIPTION
The params property in fact and event, support an array of [Record<Keys, Type>](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type).
I've updated the Typescript type of params. I've moved the type into _TParams_, which replaces _Record<string, any>_