### PR TITLE
Add react-rules to related projects README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ localStorage.debug = 'json-rules-engine'
 
 ## Related Projects
 
+_The following community projects integrate with or build on json-rules-engine. They are not maintained or endorsed by the json-rules-engine team — use at your own discretion._
 ### [JSON Rules Editor](https://github.com/vinzdeveloper/json-rule-editor)
 
 Configuration ui for json-rules-engine.


### PR DESCRIPTION
I'm the author of [react-rules](https://github.com/rafenden/react-rules), some users of [json-rules-engine](https://github.com/rafenden/react-rules) might find it useful.