### PR TITLE
Add scoped nested rules

### DIFF
--- a/src/almanac.js
+++ b/src/almanac.js
@@ -183,4 +183,18 @@ export default class Almanac {
     }
     return Promise.resolve(value)
   }
+
+  /**
+   * Resolves a path - only valid in scoped context (ScopedAlmanac)
+   * This method exists to provide a clear error when path-only conditions
+   * are used outside of a nested condition context
+   * @param {string} path - the path to resolve
+   * @return {Promise} rejects with an error
+   */
+  resolvePath (path) {
+    return Promise.reject(new Error(
+      `Almanac::resolvePath - path-only conditions (path: "${path}") can only be used inside nested conditions. ` +
+      'Ensure this condition is within a "some" or "every" operator block.'
+    ))
+  }
 }

--- a/src/json-rules-engine.js
+++ b/src/json-rules-engine.js
@@ -3,9 +3,10 @@ import Fact from './fact'
 import Rule from './rule'
 import Operator from './operator'
 import Almanac from './almanac'
+import ScopedAlmanac from './scoped-almanac'
 import OperatorDecorator from './operator-decorator'
 
-export { Fact, Rule, Operator, Engine, Almanac, OperatorDecorator }
+export { Fact, Rule, Operator, Engine, Almanac, ScopedAlmanac, OperatorDecorator }
 export default function (rules, options) {
   return new Engine(rules, options)
 }

--- a/src/scoped-almanac.js
+++ b/src/scoped-almanac.js
@@ -1,0 +1,61 @@
+'use strict'
+
+import debug from './debug'
+
+/**
+ * Scoped Almanac for nested condition evaluation
+ * Wraps a parent almanac but prioritizes item properties for fact resolution
+ */
+export default class ScopedAlmanac {
+  constructor (parentAlmanac, item) {
+    this.parentAlmanac = parentAlmanac
+    this.item = item
+  }
+
+  /**
+   * Retrieves a fact value, first checking if it's a property on the current item
+   * @param {string} factId - fact identifier
+   * @param {Object} params - parameters to feed into the fact
+   * @param {string} path - object path
+   * @return {Promise} resolves with the fact value
+   */
+  factValue (factId, params = {}, path = '') {
+    // First check if factId is a property on the current item
+    if (this.item != null && typeof this.item === 'object' &&
+        Object.prototype.hasOwnProperty.call(this.item, factId)) {
+      let value = this.item[factId]
+      debug('scoped-almanac::factValue found property on item', { factId, value })
+      // Apply path if provided
+      if (path) {
+        value = this.parentAlmanac.pathResolver(value, path)
+        debug('scoped-almanac::factValue resolved path', { path, value })
+      }
+      return Promise.resolve(value)
+    }
+    // Fall back to parent almanac
+    debug('scoped-almanac::factValue falling back to parent almanac', { factId })
+    return this.parentAlmanac.factValue(factId, params, path)
+  }
+
+  /**
+   * Interprets value as either a primitive, or if a fact, retrieves the fact value
+   * Delegates to parent almanac's getValue
+   * @param {*} value - the value to interpret
+   * @return {Promise} resolves with the value
+   */
+  getValue (value) {
+    // If the value references a fact, we need to resolve it through our scoped factValue
+    if (value != null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'fact')) {
+      return this.factValue(value.fact, value.params, value.path)
+    }
+    return Promise.resolve(value)
+  }
+
+  /**
+   * Expose pathResolver from parent almanac
+   * @returns {Function} the path resolver function
+   */
+  get pathResolver () {
+    return this.parentAlmanac.pathResolver
+  }
+}

--- a/src/scoped-almanac.js
+++ b/src/scoped-almanac.js
@@ -13,6 +13,23 @@ export default class ScopedAlmanac {
   }
 
   /**
+   * Resolves a path directly on the current scoped item
+   * Used by scoped conditions that have path but no fact
+   * @param {string} path - JSONPath to resolve on the item (e.g., '$.state' or '$.nested.property')
+   * @return {Promise} resolves with the value at the path
+   */
+  resolvePath (path) {
+    if (this.item == null) {
+      debug('scoped-almanac::resolvePath item is null')
+      return Promise.resolve(undefined)
+    }
+
+    const value = this.parentAlmanac.pathResolver(this.item, path)
+    debug('scoped-almanac::resolvePath', { path, value, item: this.item })
+    return Promise.resolve(value)
+  }
+
+  /**
    * Retrieves a fact value, first checking if it's a property on the current item
    * @param {string} factId - fact identifier
    * @param {Object} params - parameters to feed into the fact
@@ -39,14 +56,21 @@ export default class ScopedAlmanac {
 
   /**
    * Interprets value as either a primitive, or if a fact, retrieves the fact value
-   * Delegates to parent almanac's getValue
+   * Handles both fact references and path-only references for scoped conditions
    * @param {*} value - the value to interpret
    * @return {Promise} resolves with the value
    */
   getValue (value) {
-    // If the value references a fact, we need to resolve it through our scoped factValue
-    if (value != null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'fact')) {
-      return this.factValue(value.fact, value.params, value.path)
+    if (value != null && typeof value === 'object') {
+      // If value references a fact, resolve through scoped factValue
+      if (Object.prototype.hasOwnProperty.call(value, 'fact')) {
+        return this.factValue(value.fact, value.params, value.path)
+      }
+      // If value only has a path (for scoped comparisons), resolve directly on item
+      if (Object.prototype.hasOwnProperty.call(value, 'path') &&
+          !Object.prototype.hasOwnProperty.call(value, 'fact')) {
+        return this.resolvePath(value.path)
+      }
     }
     return Promise.resolve(value)
   }

--- a/test/condition.test.js
+++ b/test/condition.test.js
@@ -323,10 +323,18 @@ describe('Condition', () => {
       expect(() => new Condition(conditions)).to.throw(/Condition: constructor "operator" property required/)
     })
 
-    it('throws for a missing "fact"', () => {
+    it('throws for a missing "fact" when no path provided', () => {
       const conditions = condition()
       delete conditions.all[0].fact
+      delete conditions.all[0].path
       expect(() => new Condition(conditions)).to.throw(/Condition: constructor "fact" property required/)
+    })
+
+    it('allows path-only condition (scoped condition)', () => {
+      const conditions = condition()
+      delete conditions.all[0].fact
+      // path, operator, and value are present - this is a valid scoped condition
+      expect(() => new Condition(conditions)).to.not.throw()
     })
 
     it('throws for a missing "value"', () => {

--- a/test/engine-nested-conditions.test.js
+++ b/test/engine-nested-conditions.test.js
@@ -1,0 +1,818 @@
+'use strict'
+
+import sinon from 'sinon'
+import engineFactory from '../src/index'
+
+describe('Engine: nested conditions', () => {
+  let engine
+  let sandbox
+
+  before(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('basic nested condition with "some" operator', () => {
+    const event = {
+      type: 'bonus-threshold-met'
+    }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('emits when at least one array item matches all nested conditions', async () => {
+      const conditions = {
+        all: [{
+          fact: 'payrollItems',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'type', operator: 'equal', value: 'bonus' },
+              { fact: 'amount', operator: 'greaterThan', value: 300 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('payrollItems', [
+        { type: 'bonus', amount: 500 },
+        { type: 'salary', amount: 1000 },
+        { type: 'bonus', amount: 200 }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+
+    it('does not emit when no array item matches all nested conditions', async () => {
+      const conditions = {
+        all: [{
+          fact: 'payrollItems',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'type', operator: 'equal', value: 'bonus' },
+              { fact: 'amount', operator: 'greaterThan', value: 300 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('payrollItems', [
+        { type: 'bonus', amount: 100 },
+        { type: 'salary', amount: 1000 },
+        { type: 'bonus', amount: 200 }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('nested condition with "all" inside conditions', () => {
+    const event = { type: 'all-conditions-match' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('passes when all conditions inside match for at least one item', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'status', operator: 'equal', value: 'active' },
+              { fact: 'count', operator: 'greaterThan', value: 5 },
+              { fact: 'enabled', operator: 'equal', value: true }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { status: 'inactive', count: 10, enabled: true },
+        { status: 'active', count: 10, enabled: true },
+        { status: 'active', count: 3, enabled: true }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+  })
+
+  describe('nested condition with "any" inside conditions', () => {
+    const event = { type: 'any-condition-match' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('passes when any condition inside matches for at least one item', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            any: [
+              { fact: 'status', operator: 'equal', value: 'premium' },
+              { fact: 'level', operator: 'greaterThan', value: 10 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { status: 'basic', level: 1 },
+        { status: 'basic', level: 15 }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+
+    it('fails when no item matches any condition', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            any: [
+              { fact: 'status', operator: 'equal', value: 'premium' },
+              { fact: 'level', operator: 'greaterThan', value: 10 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { status: 'basic', level: 1 },
+        { status: 'standard', level: 5 }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('nested condition with "not" inside conditions', () => {
+    const event = { type: 'not-condition-match' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('passes when negated condition is false for at least one item', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            not: {
+              fact: 'disabled',
+              operator: 'equal',
+              value: true
+            }
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { disabled: true },
+        { disabled: false }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+
+    it('fails when negated condition is true for all items', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            not: {
+              fact: 'disabled',
+              operator: 'equal',
+              value: true
+            }
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { disabled: true },
+        { disabled: true }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('recursive nesting (nested within nested)', () => {
+    const event = { type: 'recursive-nested-match' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('supports nested conditions within nested conditions', async () => {
+      const conditions = {
+        all: [{
+          fact: 'departments',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'name', operator: 'equal', value: 'Engineering' },
+              {
+                fact: 'employees',
+                operator: 'some',
+                conditions: {
+                  all: [
+                    { fact: 'role', operator: 'equal', value: 'developer' },
+                    { fact: 'yearsExperience', operator: 'greaterThan', value: 5 }
+                  ]
+                }
+              }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('departments', [
+        {
+          name: 'Sales',
+          employees: [
+            { role: 'manager', yearsExperience: 10 }
+          ]
+        },
+        {
+          name: 'Engineering',
+          employees: [
+            { role: 'developer', yearsExperience: 2 },
+            { role: 'developer', yearsExperience: 8 }
+          ]
+        }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+
+    it('fails when inner nested condition does not match', async () => {
+      const conditions = {
+        all: [{
+          fact: 'departments',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'name', operator: 'equal', value: 'Engineering' },
+              {
+                fact: 'employees',
+                operator: 'some',
+                conditions: {
+                  all: [
+                    { fact: 'role', operator: 'equal', value: 'developer' },
+                    { fact: 'yearsExperience', operator: 'greaterThan', value: 5 }
+                  ]
+                }
+              }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('departments', [
+        {
+          name: 'Engineering',
+          employees: [
+            { role: 'developer', yearsExperience: 2 },
+            { role: 'developer', yearsExperience: 3 }
+          ]
+        }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('empty array returns false', () => {
+    const event = { type: 'empty-array-test' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('returns false when array is empty', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'value', operator: 'greaterThan', value: 0 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('non-array fact returns false', () => {
+    const event = { type: 'non-array-test' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('returns false when fact is not an array (object)', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'value', operator: 'greaterThan', value: 0 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', { value: 100 })
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+
+    it('returns false when fact is null', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'value', operator: 'greaterThan', value: 0 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', null)
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+
+    it('returns false when fact is a primitive', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'value', operator: 'greaterThan', value: 0 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', 'string value')
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('path support in parent condition', () => {
+    const event = { type: 'path-support-test' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('supports path on the parent condition to extract array', async () => {
+      const conditions = {
+        all: [{
+          fact: 'data',
+          path: '$.items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'type', operator: 'equal', value: 'special' }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('data', {
+        items: [
+          { type: 'regular' },
+          { type: 'special' }
+        ]
+      })
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+  })
+
+  describe('path support in nested conditions', () => {
+    const event = { type: 'nested-path-test' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('supports path on nested condition facts', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'metadata', path: '$.status', operator: 'equal', value: 'active' }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { metadata: { status: 'inactive' } },
+        { metadata: { status: 'active' } }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+  })
+
+  describe('nested conditions with fact params', () => {
+    const event = { type: 'fact-params-test' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('supports params on the parent condition fact', async () => {
+      const conditions = {
+        all: [{
+          fact: 'getData',
+          params: { category: 'electronics' },
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'price', operator: 'lessThan', value: 100 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('getData', (params) => {
+        if (params.category === 'electronics') {
+          return [
+            { name: 'phone', price: 500 },
+            { name: 'cable', price: 50 }
+          ]
+        }
+        return []
+      })
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+  })
+
+  describe('fallback to parent almanac for non-item properties', () => {
+    const event = { type: 'parent-almanac-fallback' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('uses parent almanac for facts not on the current item', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'type', operator: 'equal', value: 'bonus' },
+              { fact: 'minimumAmount', operator: 'lessThan', value: { fact: 'amount' } }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('items', [
+        { type: 'bonus', amount: 500 },
+        { type: 'salary', amount: 1000 }
+      ])
+      engine.addFact('minimumAmount', 300)
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+  })
+
+  describe('toJSON serialization', () => {
+    it('correctly serializes nested conditions', () => {
+      engine = engineFactory()
+
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'type', operator: 'equal', value: 'special' },
+              { fact: 'count', operator: 'greaterThan', value: 10 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event: { type: 'test' } })
+      engine.addRule(rule)
+
+      const json = engine.rules[0].toJSON(false)
+      expect(json.conditions.all[0].operator).to.equal('some')
+      expect(json.conditions.all[0].fact).to.equal('items')
+      expect(json.conditions.all[0].conditions.all).to.have.length(2)
+      expect(json.conditions.all[0].conditions.all[0].fact).to.equal('type')
+      expect(json.conditions.all[0].conditions.all[1].fact).to.equal('count')
+    })
+  })
+
+  describe('nested conditions with multiple nested conditions at same level', () => {
+    const event = { type: 'multiple-nested' }
+
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('evaluates multiple nested conditions correctly', async () => {
+      const conditions = {
+        all: [
+          {
+            fact: 'orders',
+            operator: 'some',
+            conditions: {
+              all: [
+                { fact: 'status', operator: 'equal', value: 'completed' }
+              ]
+            }
+          },
+          {
+            fact: 'payments',
+            operator: 'some',
+            conditions: {
+              all: [
+                { fact: 'verified', operator: 'equal', value: true }
+              ]
+            }
+          }
+        ]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('orders', [
+        { status: 'pending' },
+        { status: 'completed' }
+      ])
+      engine.addFact('payments', [
+        { verified: false },
+        { verified: true }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.have.been.calledWith(event)
+    })
+
+    it('fails when one nested condition fails', async () => {
+      const conditions = {
+        all: [
+          {
+            fact: 'orders',
+            operator: 'some',
+            conditions: {
+              all: [
+                { fact: 'status', operator: 'equal', value: 'completed' }
+              ]
+            }
+          },
+          {
+            fact: 'payments',
+            operator: 'some',
+            conditions: {
+              all: [
+                { fact: 'verified', operator: 'equal', value: true }
+              ]
+            }
+          }
+        ]
+      }
+
+      const rule = factories.rule({ conditions, event })
+      engine.addRule(rule)
+
+      engine.addFact('orders', [
+        { status: 'pending' },
+        { status: 'completed' }
+      ])
+      engine.addFact('payments', [
+        { verified: false },
+        { verified: false }
+      ])
+
+      const eventSpy = sandbox.spy()
+      engine.on('success', eventSpy)
+
+      await engine.run()
+      expect(eventSpy).to.not.have.been.called()
+    })
+  })
+
+  describe('result tracking in nested conditions', () => {
+    beforeEach(() => {
+      engine = engineFactory()
+    })
+
+    it('sets factResult and result on the nested condition', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'value', operator: 'greaterThan', value: 50 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event: { type: 'test' } })
+      engine.addRule(rule)
+
+      const items = [
+        { value: 30 },
+        { value: 100 }
+      ]
+      engine.addFact('items', items)
+
+      const results = await engine.run()
+
+      const nestedCondition = results.results[0].conditions.all[0]
+      expect(nestedCondition.result).to.equal(true)
+      expect(nestedCondition.factResult).to.deep.equal(items)
+    })
+
+    it('sets result to false when no items match', async () => {
+      const conditions = {
+        all: [{
+          fact: 'items',
+          operator: 'some',
+          conditions: {
+            all: [
+              { fact: 'value', operator: 'greaterThan', value: 200 }
+            ]
+          }
+        }]
+      }
+
+      const rule = factories.rule({ conditions, event: { type: 'test' } })
+      engine.addRule(rule)
+
+      const items = [
+        { value: 30 },
+        { value: 100 }
+      ]
+      engine.addFact('items', items)
+
+      const results = await engine.run()
+
+      const nestedCondition = results.failureResults[0].conditions.all[0]
+      expect(nestedCondition.result).to.equal(false)
+      expect(nestedCondition.factResult).to.deep.equal(items)
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,6 +103,20 @@ export class Almanac {
   addRuntimeFact(factId: string, value: any): void;
 }
 
+/**
+ * Scoped Almanac for nested condition evaluation
+ * Wraps a parent almanac but prioritizes item properties for fact resolution
+ */
+export class ScopedAlmanac {
+  constructor(parentAlmanac: Almanac, item: any);
+  factValue<T>(
+    factId: string,
+    params?: Record<string, any>,
+    path?: string
+  ): Promise<T>;
+  getValue<T>(value: any): Promise<T>;
+}
+
 export type FactOptions = {
   cache?: boolean;
   priority?: number;
@@ -209,10 +223,28 @@ interface ConditionProperties {
   name?: string;
 }
 
+/**
+ * Nested condition that evaluates conditions against array items
+ * Uses the 'some' operator to check if at least one array item matches
+ */
+interface NestedConditionProperties {
+  fact: string;
+  operator: 'some';
+  conditions: TopLevelCondition;
+  path?: string;
+  priority?: number;
+  params?: Record<string, any>;
+  name?: string;
+}
+
+interface NestedConditionPropertiesResult extends NestedConditionProperties, ConditionResultProperties {
+  conditions: TopLevelConditionResult;
+}
+
 type ConditionPropertiesResult = ConditionProperties & ConditionResultProperties
 
-type NestedCondition = ConditionProperties | TopLevelCondition;
-type NestedConditionResult = ConditionPropertiesResult | TopLevelConditionResult;
+type NestedCondition = ConditionProperties | NestedConditionProperties | TopLevelCondition;
+type NestedConditionResult = ConditionPropertiesResult | NestedConditionPropertiesResult | TopLevelConditionResult;
 type AllConditions = {
   all: NestedCondition[];
   name?: string;


### PR DESCRIPTION
  Added Scoped Nested Rules Feature                                                                                                                                                     
                                                                                                                                                                                        
  1. New ScopedAlmanac class (src/scoped-almanac.js)                                                                                                                                    
    - Wraps a parent almanac with a specific array item context                                                                                                                         
    - Allows conditions inside nested rules to access properties directly on the current array item                                                                                     
    - Supports resolvePath() to resolve JSONPath directly on the scoped item                                                                                                            
    - Falls back to parent almanac for facts not found on the item                                                                                                                      
  2. New some operator for nested conditions (src/condition.js)                                                                                                                         
    - Added isNestedCondition() - detects operator: 'some' with a conditions property                                                                                                   
    - Added isScopedCondition() - detects path-only conditions (no fact, just path + operator)                                                                                          
    - Scoped conditions work inside nested blocks where the "fact" is implicitly the current array item                                                                                 
  3. Updated rule evaluation (src/rule.js)                                                                                                                                              
    - Added evaluateNestedCondition() to iterate over array items                                                                                                                       
    - Creates a ScopedAlmanac for each array item and evaluates nested conditions against it                                                                                            
    - Short-circuits on first match (returns true as soon as any item matches)                                                                                                          
    - Threaded currentAlmanac through all evaluation functions (evaluateCondition, all, any, not, realize, etc.)                                                                        
  4. Error handling (src/almanac.js)                                                                                                                                                    
    - Added resolvePath() stub that throws helpful error if path-only conditions are used outside nested context                                                                        
  5. TypeScript definitions (types/index.d.ts) - Updated types to support the new structures                                                                                            
  6. Comprehensive tests (test/engine-nested-conditions.test.js) - ~1100 lines of test coverage      